### PR TITLE
feat: make resourceId optional in worker pipeline

### DIFF
--- a/src/engine.test.ts
+++ b/src/engine.test.ts
@@ -367,6 +367,22 @@ describe('WorkflowEngine', () => {
       });
     });
 
+    it('should start and complete without resourceId', async () => {
+      const run = await engine.startWorkflow({
+        workflowId: 'test-workflow',
+        input: { data: 'no-resource' },
+      });
+
+      expect(run.resourceId).toBeNull();
+
+      await expect
+        .poll(async () => (await engine.getRun({ runId: run.id })).status)
+        .toBe(WorkflowStatus.COMPLETED);
+
+      const completed = await engine.getRun({ runId: run.id });
+      expect(completed.output).toEqual({ result: 'no-resource' });
+    });
+
     it('should start workflow with options', async () => {
       const run = await engine.startWorkflow({
         resourceId: 'testResourceId',
@@ -616,6 +632,43 @@ describe('WorkflowEngine', () => {
         totalSteps: 2,
         completedSteps: 2,
       });
+    });
+
+    it('should complete waitFor when triggerEvent omits resourceId for a scoped run', async () => {
+      const waitForWorkflowScoped = workflow(
+        'wait-for-workflow-scoped-trigger',
+        async ({ step }) => {
+          await step.run('step-1', async () => 'result-1');
+          await step.waitFor('step-2', { eventName: 'user-action' });
+          return 'completed';
+        },
+      );
+
+      await engine.registerWorkflow(waitForWorkflowScoped);
+      const scopedResource = 'scoped-tenant-trigger-test';
+      const run = await engine.startWorkflow({
+        resourceId: scopedResource,
+        workflowId: 'wait-for-workflow-scoped-trigger',
+        input: {},
+      });
+
+      await expect
+        .poll(
+          async () => (await engine.getRun({ runId: run.id, resourceId: scopedResource })).status,
+        )
+        .toBe(WorkflowStatus.PAUSED);
+
+      await engine.triggerEvent({
+        runId: run.id,
+        eventName: 'user-action',
+        data: { accepted: true },
+      });
+
+      await expect
+        .poll(
+          async () => (await engine.getRun({ runId: run.id, resourceId: scopedResource })).status,
+        )
+        .toBe(WorkflowStatus.COMPLETED);
     });
 
     it('should handle workflow with pause step', async () => {

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -397,9 +397,11 @@ export class WorkflowEngine {
 
     const run = await this.getRun({ runId, resourceId });
 
+    const jobResourceId = resourceId ?? run.resourceId ?? undefined;
+
     const job: WorkflowRunJobParameters = {
       runId: run.id,
-      resourceId,
+      resourceId: jobResourceId,
       workflowId: run.workflowId,
       input: run.input,
       event: {
@@ -501,15 +503,37 @@ export class WorkflowEngine {
     };
   }
 
+  /**
+   * Resolves the resource id used for scoped DB access (getRun/updateRun).
+   * When the job omits resourceId, the run's stored resourceId is used.
+   * When the job includes resourceId, it must match the run's resourceId if the run is scoped;
+   * unscoped runs reject a job-supplied resourceId (authorization).
+   */
+  private resolveScopedResourceId(
+    jobResourceId: string | undefined,
+    run: WorkflowRun,
+  ): string | undefined {
+    const jobResourceProvided =
+      jobResourceId !== undefined && jobResourceId !== null && jobResourceId !== '';
+
+    if (jobResourceProvided) {
+      if (run.resourceId === null) {
+        throw new WorkflowRunNotFoundError(run.id);
+      }
+      if (run.resourceId !== jobResourceId) {
+        throw new WorkflowRunNotFoundError(run.id);
+      }
+      return jobResourceId;
+    }
+
+    return run.resourceId ?? undefined;
+  }
+
   private async handleWorkflowRun([job]: Job<WorkflowRunJobParameters>[]) {
     const { runId, resourceId, workflowId, input, event } = job?.data ?? {};
 
     if (!runId) {
       throw new WorkflowEngineError('Invalid workflow run job, missing runId', workflowId);
-    }
-
-    if (!resourceId) {
-      throw new WorkflowEngineError('Invalid workflow run job, missing resourceId', workflowId);
     }
 
     if (!workflowId) {
@@ -530,7 +554,17 @@ export class WorkflowEngine {
       workflowId,
     });
 
-    let run = await this.getRun({ runId, resourceId });
+    let run = await this.getRun({ runId });
+
+    if (run.workflowId !== workflowId) {
+      throw new WorkflowEngineError(
+        `Workflow run ${runId} does not match job workflowId ${workflowId}`,
+        workflowId,
+        runId,
+      );
+    }
+
+    const scopedResourceId = this.resolveScopedResourceId(resourceId, run);
 
     try {
       if (run.status === WorkflowStatus.CANCELLED) {
@@ -563,7 +597,7 @@ export class WorkflowEngine {
           const skipOutput = waitFor?.skipOutput;
           run = await this.updateRun({
             runId,
-            resourceId,
+            resourceId: scopedResourceId,
             data: {
               status: WorkflowStatus.RUNNING,
               pausedAt: null,
@@ -585,7 +619,7 @@ export class WorkflowEngine {
         } else {
           run = await this.updateRun({
             runId,
-            resourceId,
+            resourceId: scopedResourceId,
             data: {
               status: WorkflowStatus.RUNNING,
               pausedAt: null,
@@ -692,7 +726,7 @@ export class WorkflowEngine {
 
       const result = await workflow.handler(context);
 
-      run = await this.getRun({ runId, resourceId });
+      run = await this.getRun({ runId, resourceId: scopedResourceId });
 
       const isLastParsedStep = run.currentStepId === workflow.steps[workflow.steps.length - 1]?.id;
       const hasPluginSteps = (workflow.plugins?.length ?? 0) > 0;
@@ -704,7 +738,7 @@ export class WorkflowEngine {
         const normalizedResult = result === undefined ? {} : result;
         await this.updateRun({
           runId,
-          resourceId,
+          resourceId: scopedResourceId,
           data: {
             status: WorkflowStatus.COMPLETED,
             output: normalizedResult,
@@ -722,7 +756,7 @@ export class WorkflowEngine {
       if (run.retryCount < run.maxRetries) {
         await this.updateRun({
           runId,
-          resourceId,
+          resourceId: scopedResourceId,
           data: {
             retryCount: run.retryCount + 1,
             jobId: job?.id,
@@ -734,7 +768,7 @@ export class WorkflowEngine {
         // NOTE: Do not use pg-boss retryLimit and retryBackoff so that we can fully control the retry logic from the WorkflowEngine and not PGBoss.
         const pgBossJob: WorkflowRunJobParameters = {
           runId,
-          resourceId,
+          resourceId: scopedResourceId,
           workflowId,
           input,
         };
@@ -749,7 +783,7 @@ export class WorkflowEngine {
       // TODO: Ensure that this code always runs, even if worker is stopped unexpectedly.
       await this.updateRun({
         runId,
-        resourceId,
+        resourceId: scopedResourceId,
         data: {
           status: WorkflowStatus.FAILED,
           error: error instanceof Error ? error.message : String(error),

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -16,19 +16,25 @@ let engine: WorkflowEngine;
 
 async function waitForStatus(
   runId: string,
-  resourceId: string,
+  resourceId: string | undefined,
   targetStatuses: string[],
   timeoutMs = POLL_TIMEOUT_MS,
 ) {
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
-    const progress = await engine.checkProgress({ runId, resourceId });
+    const progress =
+      resourceId !== undefined
+        ? await engine.checkProgress({ runId, resourceId })
+        : await engine.checkProgress({ runId });
     if (targetStatuses.includes(progress.status)) {
       return progress;
     }
     await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
   }
-  const final = await engine.checkProgress({ runId, resourceId });
+  const final =
+    resourceId !== undefined
+      ? await engine.checkProgress({ runId, resourceId })
+      : await engine.checkProgress({ runId });
   throw new Error(
     `Timed out waiting for status [${targetStatuses}]. Current: ${final.status}, step: ${final.currentStepId}`,
   );
@@ -196,6 +202,20 @@ describe('WorkflowEngine Integration (real PostgreSQL)', () => {
     expect(result.error).toBeNull();
   });
 
+  it('should complete sequential workflow without resourceId', async () => {
+    const run = await engine.startWorkflow({
+      workflowId: 'integration-sequential',
+      input: {},
+    });
+
+    expect(run.resourceId).toBeNull();
+
+    const result = await waitForStatus(run.id, undefined, ['completed']);
+
+    expect(result.status).toBe(WorkflowStatus.COMPLETED);
+    expect(result.completionPercentage).toBe(100);
+  });
+
   it('should validate input with Zod schema', async () => {
     const resourceId = `test-input-${Date.now()}`;
 
@@ -246,6 +266,30 @@ describe('WorkflowEngine Integration (real PostgreSQL)', () => {
     });
 
     // Wait for completion
+    const result = await waitForStatus(run.id, resourceId, ['completed']);
+    expect(result.status).toBe(WorkflowStatus.COMPLETED);
+    expect(result.output).toEqual({
+      setup: { ready: true },
+      approved: true,
+    });
+  });
+
+  it('should resume waitFor when triggerEvent omits resourceId', async () => {
+    const resourceId = `test-event-no-res-${Date.now()}`;
+    const run = await engine.startWorkflow({
+      workflowId: 'integration-wait-for-event',
+      resourceId,
+      input: {},
+    });
+
+    await waitForStatus(run.id, resourceId, ['paused']);
+
+    await engine.triggerEvent({
+      runId: run.id,
+      eventName: 'approval',
+      data: { approved: true },
+    });
+
     const result = await waitForStatus(run.id, resourceId, ['completed']);
     expect(result.status).toBe(WorkflowStatus.COMPLETED);
     expect(result.output).toEqual({


### PR DESCRIPTION
- Remove hard resourceId check in handleWorkflowRun
- Resolve scopedResourceId from run when job omits resourceId
- Use resolved scopedResourceId for all updateRun/getRun and retries
- triggerEvent: set job resourceId to run.resourceId when omitted
- When job provides resourceId, validate against run for authorization
- Add tests: start/complete without resourceId, triggerEvent without resourceId