### PR TITLE
feat(client): expose idempotencyKey on WorkflowClient.startWorkflow

### DIFF
--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -1,0 +1,111 @@
+import type pg from 'pg';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { WorkflowClient } from './client';
+import { createWorkflowRef } from './definition';
+import { closeTestDatabase, createTestDatabase } from './tests/test-db';
+
+let testPool: pg.Pool;
+
+beforeAll(async () => {
+  testPool = await createTestDatabase();
+});
+
+afterAll(async () => {
+  await closeTestDatabase();
+});
+
+const testRef = createWorkflowRef('test-client-workflow', {
+  inputSchema: z.object({ data: z.string() }),
+});
+
+describe('WorkflowClient', () => {
+  const resourceId = 'testResourceId';
+  let client: WorkflowClient;
+
+  beforeEach(async () => {
+    client = new WorkflowClient({ pool: testPool });
+  });
+
+  afterEach(async () => {
+    await client.stop();
+  });
+
+  describe('startWorkflow idempotency', () => {
+    it('returns the same run when called twice with the same idempotencyKey (params overload)', async () => {
+      const run1 = await client.startWorkflow({
+        resourceId,
+        workflowId: 'test-client-workflow',
+        input: { data: 'hello' },
+        idempotencyKey: 'client-key-1',
+      });
+
+      const run2 = await client.startWorkflow({
+        resourceId,
+        workflowId: 'test-client-workflow',
+        input: { data: 'hello' },
+        idempotencyKey: 'client-key-1',
+      });
+
+      expect(run1.id).toBe(run2.id);
+      expect(run1.idempotencyKey).toBe('client-key-1');
+      expect(run2.idempotencyKey).toBe('client-key-1');
+    });
+
+    it('returns the same run when called twice with the same idempotencyKey (ref overload)', async () => {
+      const run1 = await client.startWorkflow(
+        testRef,
+        { data: 'hello' },
+        { resourceId, idempotencyKey: 'client-key-ref-1' },
+      );
+
+      const run2 = await client.startWorkflow(
+        testRef,
+        { data: 'hello' },
+        { resourceId, idempotencyKey: 'client-key-ref-1' },
+      );
+
+      expect(run1.id).toBe(run2.id);
+      expect(run1.idempotencyKey).toBe('client-key-ref-1');
+      expect(run2.idempotencyKey).toBe('client-key-ref-1');
+    });
+
+    it('creates two runs when no idempotencyKey is provided', async () => {
+      const run1 = await client.startWorkflow({
+        resourceId,
+        workflowId: 'test-client-workflow',
+        input: { data: 'a' },
+      });
+
+      const run2 = await client.startWorkflow({
+        resourceId,
+        workflowId: 'test-client-workflow',
+        input: { data: 'b' },
+      });
+
+      expect(run1.id).not.toBe(run2.id);
+      expect(run1.idempotencyKey).toBeNull();
+      expect(run2.idempotencyKey).toBeNull();
+    });
+
+    it('creates two runs when different idempotencyKeys are provided', async () => {
+      const run1 = await client.startWorkflow({
+        resourceId,
+        workflowId: 'test-client-workflow',
+        input: { data: 'x' },
+        idempotencyKey: 'client-key-a',
+      });
+
+      const run2 = await client.startWorkflow({
+        resourceId,
+        workflowId: 'test-client-workflow',
+        input: { data: 'y' },
+        idempotencyKey: 'client-key-b',
+      });
+
+      expect(run1.id).not.toBe(run2.id);
+      expect(run1.idempotencyKey).toBe('client-key-a');
+      expect(run2.idempotencyKey).toBe('client-key-b');
+    });
+  });
+});

--- a/src/client.ts
+++ b/src/client.ts
@@ -43,6 +43,7 @@ export type StartWorkflowOptions = {
   timeout?: number;
   retries?: number;
   expireInSeconds?: number;
+  idempotencyKey?: string;
 };
 
 const defaultLogger: WorkflowLogger = {
@@ -118,6 +119,7 @@ export class WorkflowClient {
     workflowId: string;
     input: unknown;
     resourceId?: string;
+    idempotencyKey?: string;
     options?: StartWorkflowOptions;
   }): Promise<WorkflowRun>;
 
@@ -128,6 +130,7 @@ export class WorkflowClient {
           workflowId: string;
           input: unknown;
           resourceId?: string;
+          idempotencyKey?: string;
           options?: StartWorkflowOptions;
         },
     inputArg?: InferInputParameters<TInput>,
@@ -138,6 +141,7 @@ export class WorkflowClient {
     let workflowId: string;
     let input: unknown;
     let resourceId: string | undefined;
+    let idempotencyKey: string | undefined;
     let options: StartWorkflowOptions | undefined;
 
     if (typeof refOrParams === 'function' && 'id' in refOrParams) {
@@ -146,6 +150,7 @@ export class WorkflowClient {
       input = inputArg;
       options = optionsArg;
       resourceId = optionsArg?.resourceId;
+      idempotencyKey = optionsArg?.idempotencyKey;
 
       if (ref.inputSchema) {
         const result = await ref.inputSchema['~standard'].validate(input);
@@ -164,11 +169,13 @@ export class WorkflowClient {
         workflowId: string;
         input: unknown;
         resourceId?: string;
+        idempotencyKey?: string;
         options?: StartWorkflowOptions;
       };
       workflowId = params.workflowId;
       input = params.input;
       resourceId = params.resourceId;
+      idempotencyKey = params.idempotencyKey;
       options = params.options;
     }
 
@@ -186,6 +193,7 @@ export class WorkflowClient {
             input,
             maxRetries: options?.retries ?? 0,
             timeoutAt,
+            idempotencyKey,
           },
           _db,
         );


### PR DESCRIPTION
## Summary

Adds `idempotencyKey` to `WorkflowClient.startWorkflow` to close an API gap between the client and the engine.

The engine's `startWorkflow` exposes `idempotencyKey` (top-level on the params overload + via `StartWorkflowOptions` on the ref overload) and the DB layer (`insertWorkflowRun`) already enforces uniqueness with `ON CONFLICT (idempotency_key) WHERE idempotency_key IS NOT NULL DO NOTHING`. The lightweight client, however, didn't surface the option - so API services using the client couldn't dedupe starts from at-least-once sources (webhook retries, user double-clicks), which is a [documented core feature](https://github.com/SokratisVidros/pg-workflows/blob/main/docs/core-concepts.md#idempotency) of the engine.

This PR just plumbs the option through. No behavior change beyond making the client surface match the engine.

### What's changed

- `StartWorkflowOptions` gains `idempotencyKey?: string` (used by the ref overload).
- The params-object overload gains a top-level `idempotencyKey?: string`, matching the engine's shape exactly.
- The implementation extracts `idempotencyKey` in both branches and passes it to `insertWorkflowRun`.
- `src/client.test.ts` - new unit test suite mirroring the engine's idempotency tests, covering both overloads and the no-key case.

### API after this change

```ts
// Ref overload
await client.startWorkflow(onboardUser, { email }, {
  resourceId,
  idempotencyKey: 'onboard-user:checkout_cs_abc123',
});

// Params overload
await client.startWorkflow({
  workflowId: 'onboard-user',
  input: { email },
  resourceId,
  idempotencyKey: 'onboard-user:checkout_cs_abc123',
});
```

### Build impact

`dist/client.entry.js` ESM remains 257B - type-only addition at runtime for the ref overload, one extra field read for the params overload.

## Test plan

- [x] 99/99 unit tests pass (PGlite), including 4 new client idempotency tests
- [x] `biome check` passes clean
- [x] `bunup` dual-entry build succeeds; `idempotencyKey` appears in `dist/client.entry.d.ts`
- [ ] Integration tests (require Postgres) - not run locally