### PR TITLE
feat: increase resource_id and workflow_id column length to 256

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -11,7 +11,12 @@ import {
   withPostgresTransaction,
 } from './db/queries';
 import type { WorkflowRun } from './db/types';
-import { WorkflowEngineError, WorkflowRunNotFoundError } from './error';
+import {
+  validateResourceId,
+  validateWorkflowId,
+  WorkflowEngineError,
+  WorkflowRunNotFoundError,
+} from './error';
 import {
   type InferInputParameters,
   type InputParameters,
@@ -189,6 +194,9 @@ export class WorkflowClient {
       idempotencyKey = params.idempotencyKey;
       options = params.options;
     }
+
+    validateWorkflowId(workflowId);
+    validateResourceId(resourceId);
 
     const run = await withPostgresTransaction(
       this.db,
@@ -506,6 +514,9 @@ export class WorkflowClient {
     hasPrev: boolean;
   }> {
     await this.ensureStarted();
+
+    if (workflowId) validateWorkflowId(workflowId);
+    validateResourceId(resourceId);
 
     return getWorkflowRuns(
       {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,5 @@
 export const PAUSE_EVENT_NAME = '__internal_pause';
 export const WORKFLOW_RUN_QUEUE_NAME = 'workflow-run';
 export const DEFAULT_PGBOSS_SCHEMA = 'pgboss_v12_pgworkflow';
+export const MAX_WORKFLOW_ID_LENGTH = 256;
+export const MAX_RESOURCE_ID_LENGTH = 256;

--- a/src/db/migration.ts
+++ b/src/db/migration.ts
@@ -5,7 +5,7 @@ export const MIGRATION_LOCK_ID = 738291645;
 
 // Bump this when adding new migrations. The engine stores the current version
 // in a `workflow_schema_version` table so migrations only run once per version.
-const CURRENT_SCHEMA_VERSION = 2;
+const CURRENT_SCHEMA_VERSION = 3;
 
 export async function runMigrations(db: Db): Promise<void> {
   // Fast path: skip the advisory lock if schema is already current.
@@ -29,8 +29,8 @@ export async function runMigrations(db: Db): Promise<void> {
         id varchar(32) PRIMARY KEY NOT NULL,
         created_at timestamp with time zone DEFAULT now() NOT NULL,
         updated_at timestamp with time zone DEFAULT now() NOT NULL,
-        resource_id varchar(32),
-        workflow_id varchar(32) NOT NULL,
+        resource_id varchar(256),
+        workflow_id varchar(256) NOT NULL,
         status text DEFAULT 'pending' NOT NULL,
         input jsonb NOT NULL,
         output jsonb,
@@ -72,6 +72,11 @@ export async function runMigrations(db: Db): Promise<void> {
     commands.push(`
       CREATE UNIQUE INDEX IF NOT EXISTS workflow_runs_idempotency_key_idx ON workflow_runs (idempotency_key) WHERE idempotency_key IS NOT NULL
     `);
+  }
+
+  if (currentVersion < 3) {
+    commands.push('ALTER TABLE workflow_runs ALTER COLUMN resource_id TYPE varchar(256)');
+    commands.push('ALTER TABLE workflow_runs ALTER COLUMN workflow_id TYPE varchar(256)');
   }
 
   // Upsert the schema version

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -14,7 +14,12 @@ import {
 import type { WorkflowRun } from './db/types';
 import type { Duration } from './duration';
 import { parseDuration } from './duration';
-import { WorkflowEngineError, WorkflowRunNotFoundError } from './error';
+import {
+  validateResourceId,
+  validateWorkflowId,
+  WorkflowEngineError,
+  WorkflowRunNotFoundError,
+} from './error';
 import {
   type InferInputParameters,
   type InputParameters,
@@ -280,6 +285,9 @@ export class WorkflowEngine {
       idempotencyKey = params.idempotencyKey;
       options = params.options;
     }
+
+    validateWorkflowId(workflowId);
+    validateResourceId(resourceId);
 
     if (!this._started) {
       await this.start(false, { batchSize: options?.batchSize ?? 1 });
@@ -1422,6 +1430,9 @@ export class WorkflowEngine {
     hasMore: boolean;
     hasPrev: boolean;
   }> {
+    if (workflowId) validateWorkflowId(workflowId);
+    validateResourceId(resourceId);
+
     return getWorkflowRuns(
       {
         resourceId,

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,4 +1,22 @@
 import type { StandardSchemaV1 } from '@standard-schema/spec';
+import { MAX_RESOURCE_ID_LENGTH, MAX_WORKFLOW_ID_LENGTH } from './constants';
+
+export function validateWorkflowId(workflowId: string): void {
+  if (workflowId.length > MAX_WORKFLOW_ID_LENGTH) {
+    throw new WorkflowEngineError(
+      `workflowId exceeds maximum length of ${MAX_WORKFLOW_ID_LENGTH} characters (got ${workflowId.length})`,
+      workflowId,
+    );
+  }
+}
+
+export function validateResourceId(resourceId: string | undefined | null): void {
+  if (resourceId != null && resourceId.length > MAX_RESOURCE_ID_LENGTH) {
+    throw new WorkflowEngineError(
+      `resourceId exceeds maximum length of ${MAX_RESOURCE_ID_LENGTH} characters (got ${resourceId.length})`,
+    );
+  }
+}
 
 export class WorkflowEngineError extends Error {
   constructor(

--- a/src/migration-lock.integration.test.ts
+++ b/src/migration-lock.integration.test.ts
@@ -55,7 +55,7 @@ describe('Migration advisory lock (real PostgreSQL)', () => {
 
     // Verify the final schema state is correct
     const versionResult = await pool.query('SELECT version FROM workflow_schema_version LIMIT 1');
-    expect(versionResult.rows[0].version).toBe(2);
+    expect(versionResult.rows[0].version).toBe(3);
 
     const tableExists = await pool.query(`
       SELECT EXISTS (


### PR DESCRIPTION
## Summary
- Increases `resource_id` and `workflow_id` columns from `varchar(32)` to `varchar(256)` via a new v3 schema migration
- Adds early validation in `WorkflowEngine` and `WorkflowClient` (`startWorkflow`, `getRuns`) so callers get a clear `WorkflowEngineError` before hitting the database when values exceed 256 characters
- Updates the v1 CREATE TABLE DDL so fresh installs use `varchar(256)` from the start

## Test plan
- [x] All 100 unit tests pass
- [x] Lint and type checks pass
- [ ] Run integration tests against a real PostgreSQL instance to verify the v3 migration applies cleanly on an existing schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)