### PR TITLE
Add dead-letter queue recovery for stuck workflow runs

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,6 @@
 export const PAUSE_EVENT_NAME = '__internal_pause';
 export const WORKFLOW_RUN_QUEUE_NAME = 'workflow-run';
-export const STUCK_WORKFLOW_RUN_QUEUE_NAME = 'workflow-run-stuck';
+export const WORKFLOW_RUN_DLQ_QUEUE_NAME = 'workflow_run_dlq';
 export const DEFAULT_PGBOSS_SCHEMA = 'pgboss_v12_pgworkflow';
 export const MAX_WORKFLOW_ID_LENGTH = 256;
 export const MAX_RESOURCE_ID_LENGTH = 256;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,6 @@
 export const PAUSE_EVENT_NAME = '__internal_pause';
 export const WORKFLOW_RUN_QUEUE_NAME = 'workflow-run';
+export const STUCK_WORKFLOW_RUN_QUEUE_NAME = 'workflow-run-stuck';
 export const DEFAULT_PGBOSS_SCHEMA = 'pgboss_v12_pgworkflow';
 export const MAX_WORKFLOW_ID_LENGTH = 256;
 export const MAX_RESOURCE_ID_LENGTH = 256;

--- a/src/engine.test.ts
+++ b/src/engine.test.ts
@@ -1114,6 +1114,51 @@ describe('WorkflowEngine', () => {
         });
     });
 
+    it('should not re-execute completed steps when a later step fails and retries', async () => {
+      // Durability promise: on retry, step.run reads cached results from the
+      // timeline and skips the handler. If step-1 has side effects (e.g. a
+      // payment), it MUST run exactly once even if step-2 fails repeatedly.
+      let stepOneRuns = 0;
+      let stepTwoRuns = 0;
+      const cachingWorkflow = workflow(
+        'retry-caching-workflow',
+        async ({ step }) => {
+          const first = await step.run('step-1', async () => {
+            stepOneRuns++;
+            return { value: 'first' };
+          });
+          const second = await step.run('step-2', async () => {
+            stepTwoRuns++;
+            if (stepTwoRuns < 3) {
+              throw new Error(`step-2 boom #${stepTwoRuns}`);
+            }
+            return { value: `${first.value}+second` };
+          });
+          return second;
+        },
+        { retries: 5 },
+      );
+
+      await engine.registerWorkflow(cachingWorkflow);
+      const run = await engine.startWorkflow({
+        resourceId,
+        workflowId: 'retry-caching-workflow',
+        input: {},
+      });
+
+      await expect
+        .poll(async () => (await engine.getRun({ runId: run.id, resourceId })).status, {
+          timeout: 10000,
+        })
+        .toBe(WorkflowStatus.COMPLETED);
+
+      expect(stepOneRuns).toBe(1);
+      expect(stepTwoRuns).toBe(3);
+
+      const finished = await engine.getRun({ runId: run.id, resourceId });
+      expect(finished.output).toEqual({ value: 'first+second' });
+    });
+
     it('should use exponential backoff for retries', async () => {
       const failingWorkflow = workflow('backoff-workflow', async ({ step }) => {
         await step.run('step-1', async () => {
@@ -1137,6 +1182,10 @@ describe('WorkflowEngine', () => {
           timeout: 10000,
         })
         .toBe(WorkflowStatus.FAILED);
+
+      const finalRun = await engine.getRun({ runId: run.id, resourceId });
+      expect(finalRun.retryCount).toBe(2);
+      expect(finalRun.error).toBe('always fails');
 
       type JobData = { runId: string; workflowId: string };
 
@@ -1268,6 +1317,44 @@ describe('WorkflowEngine', () => {
         const after = await engine.getRun({ runId, resourceId });
         expect(after.status).toBe(WorkflowStatus.COMPLETED);
         expect(after.retryCount).toBe(0);
+      });
+
+      it('should silently no-op for DLQ jobs with missing or unknown runId', async () => {
+        // The DLQ worker must not crash on malformed/orphaned messages,
+        // otherwise a single bad payload poisons the entire DLQ pipeline.
+        await testBoss.send('workflow_run_dlq', {
+          resourceId,
+          workflowId: 'test-workflow',
+          input: {},
+        });
+
+        await testBoss.send('workflow_run_dlq', {
+          runId: 'run_does_not_exist_xyz',
+          resourceId,
+          workflowId: 'test-workflow',
+          input: {},
+        });
+
+        // A subsequent valid DLQ message should still be processed, proving
+        // the worker stayed alive through the previous two no-ops.
+        const liveRunId = await insertStuckRun({
+          workflowId: 'test-workflow',
+          retryCount: 0,
+          maxRetries: 3,
+          status: WorkflowStatus.RUNNING,
+        });
+        await testBoss.send('workflow_run_dlq', {
+          runId: liveRunId,
+          resourceId,
+          workflowId: 'test-workflow',
+          input: { data: 'stuck' },
+        });
+
+        await expect
+          .poll(async () => (await engine.getRun({ runId: liveRunId, resourceId })).retryCount, {
+            timeout: 10000,
+          })
+          .toBeGreaterThanOrEqual(1);
       });
     });
 

--- a/src/engine.test.ts
+++ b/src/engine.test.ts
@@ -1255,12 +1255,7 @@ describe('WorkflowEngine', () => {
           status: WorkflowStatus.RUNNING,
         });
 
-        await testBoss.send(WORKFLOW_RUN_DLQ_QUEUE_NAME, {
-          runId,
-          resourceId,
-          workflowId: 'test-workflow',
-          input: { data: 'stuck' },
-        });
+        await testBoss.send(WORKFLOW_RUN_DLQ_QUEUE_NAME, { runId });
 
         await expect
           .poll(async () => (await engine.getRun({ runId, resourceId })).status, {
@@ -1272,65 +1267,39 @@ describe('WorkflowEngine', () => {
         expect(failed.error).toContain('worker died');
       });
 
-      it('should not modify runs that are no longer in RUNNING status', async () => {
-        const runId = await insertStuckRun({
+      it('should ignore DLQ jobs that need no recovery and stay alive', async () => {
+        // Three no-op cases the DLQ worker must skip without crashing:
+        // (1) terminal status, (2) missing runId, (3) unknown runId.
+        // A bad payload that crashes the worker would poison the pipeline.
+        const completedRunId = await insertStuckRun({
           workflowId: 'test-workflow',
           retryCount: 0,
           maxRetries: 2,
           status: WorkflowStatus.COMPLETED,
         });
+        await testBoss.send(WORKFLOW_RUN_DLQ_QUEUE_NAME, { runId: completedRunId });
+        await testBoss.send(WORKFLOW_RUN_DLQ_QUEUE_NAME, {});
+        await testBoss.send(WORKFLOW_RUN_DLQ_QUEUE_NAME, { runId: 'run_does_not_exist_xyz' });
 
-        await testBoss.send(WORKFLOW_RUN_DLQ_QUEUE_NAME, {
-          runId,
-          resourceId,
-          workflowId: 'test-workflow',
-          input: { data: 'stuck' },
-        });
-
-        // Give the DLQ worker time to process and confirm no state change.
-        await new Promise((resolve) => setTimeout(resolve, 1500));
-
-        const after = await engine.getRun({ runId, resourceId });
-        expect(after.status).toBe(WorkflowStatus.COMPLETED);
-        expect(after.retryCount).toBe(0);
-      });
-
-      it('should silently no-op for DLQ jobs with missing or unknown runId', async () => {
-        // The DLQ worker must not crash on malformed/orphaned messages,
-        // otherwise a single bad payload poisons the entire DLQ pipeline.
-        await testBoss.send(WORKFLOW_RUN_DLQ_QUEUE_NAME, {
-          resourceId,
-          workflowId: 'test-workflow',
-          input: {},
-        });
-
-        await testBoss.send(WORKFLOW_RUN_DLQ_QUEUE_NAME, {
-          runId: 'run_does_not_exist_xyz',
-          resourceId,
-          workflowId: 'test-workflow',
-          input: {},
-        });
-
-        // A subsequent valid DLQ message should still be processed, proving
-        // the worker stayed alive through the previous two no-ops.
+        // A follow-up valid DLQ message proves the worker stayed alive past
+        // all three no-ops once it advances the live run to FAILED.
         const liveRunId = await insertStuckRun({
           workflowId: 'test-workflow',
-          retryCount: 0,
-          maxRetries: 3,
+          retryCount: 2,
+          maxRetries: 2,
           status: WorkflowStatus.RUNNING,
         });
-        await testBoss.send(WORKFLOW_RUN_DLQ_QUEUE_NAME, {
-          runId: liveRunId,
-          resourceId,
-          workflowId: 'test-workflow',
-          input: { data: 'stuck' },
-        });
+        await testBoss.send(WORKFLOW_RUN_DLQ_QUEUE_NAME, { runId: liveRunId });
 
         await expect
           .poll(async () => (await engine.getRun({ runId: liveRunId, resourceId })).status, {
             timeout: 10000,
           })
           .toBe(WorkflowStatus.FAILED);
+
+        const completed = await engine.getRun({ runId: completedRunId, resourceId });
+        expect(completed.status).toBe(WorkflowStatus.COMPLETED);
+        expect(completed.retryCount).toBe(0);
       });
     });
 

--- a/src/engine.test.ts
+++ b/src/engine.test.ts
@@ -1159,6 +1159,118 @@ describe('WorkflowEngine', () => {
       sendSpy.mockRestore();
     });
 
+    describe('dead-letter recovery for stuck runs', () => {
+      const insertStuckRun = async ({
+        workflowId,
+        retryCount,
+        maxRetries,
+        status,
+      }: {
+        workflowId: string;
+        retryCount: number;
+        maxRetries: number;
+        status: WorkflowStatus;
+      }) => {
+        const runId = `run_stuck_${Math.random().toString(36).slice(2, 10)}`;
+        const now = new Date();
+        await testPool.query(
+          `INSERT INTO workflow_runs (
+            id, resource_id, workflow_id, current_step_id, status, input,
+            max_retries, retry_count, timeline, created_at, updated_at
+          ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+          [
+            runId,
+            resourceId,
+            workflowId,
+            'step-1',
+            status,
+            JSON.stringify({ data: 'stuck' }),
+            maxRetries,
+            retryCount,
+            '{}',
+            now,
+            now,
+          ],
+        );
+        return runId;
+      };
+
+      it('should retry a stuck RUNNING run when retries are available', async () => {
+        const runId = await insertStuckRun({
+          workflowId: 'test-workflow',
+          retryCount: 0,
+          maxRetries: 3,
+          status: WorkflowStatus.RUNNING,
+        });
+
+        await testBoss.send('workflow-run-stuck', {
+          runId,
+          resourceId,
+          workflowId: 'test-workflow',
+          input: { data: 'stuck' },
+        });
+
+        // The DLQ worker should bump retryCount and re-enqueue, then the main
+        // worker picks it up and completes the workflow.
+        await expect
+          .poll(async () => (await engine.getRun({ runId, resourceId })).status, {
+            timeout: 10000,
+          })
+          .toBe(WorkflowStatus.COMPLETED);
+
+        const recovered = await engine.getRun({ runId, resourceId });
+        expect(recovered.retryCount).toBeGreaterThanOrEqual(1);
+      });
+
+      it('should mark a stuck RUNNING run as FAILED when retries are exhausted', async () => {
+        const runId = await insertStuckRun({
+          workflowId: 'test-workflow',
+          retryCount: 2,
+          maxRetries: 2,
+          status: WorkflowStatus.RUNNING,
+        });
+
+        await testBoss.send('workflow-run-stuck', {
+          runId,
+          resourceId,
+          workflowId: 'test-workflow',
+          input: { data: 'stuck' },
+        });
+
+        await expect
+          .poll(async () => (await engine.getRun({ runId, resourceId })).status, {
+            timeout: 5000,
+          })
+          .toBe(WorkflowStatus.FAILED);
+
+        const failed = await engine.getRun({ runId, resourceId });
+        expect(failed.error).toContain('worker died');
+      });
+
+      it('should not modify runs that are no longer in RUNNING status', async () => {
+        const runId = await insertStuckRun({
+          workflowId: 'test-workflow',
+          retryCount: 0,
+          maxRetries: 2,
+          status: WorkflowStatus.COMPLETED,
+        });
+
+        await testBoss.send('workflow-run-stuck', {
+          runId,
+          resourceId,
+          workflowId: 'test-workflow',
+          input: { data: 'stuck' },
+        });
+
+        // Give the DLQ worker time to process and confirm no state change.
+        await new Promise((resolve) => setTimeout(resolve, 1500));
+
+        const after = await engine.getRun({ runId, resourceId });
+        expect(after.status).toBe(WorkflowStatus.COMPLETED);
+        expect(after.retryCount).toBe(0);
+      });
+    });
+
     it('should handle workflow with waitUntil step', async () => {
       const waitUntilWorkflow = workflow('wait-until-workflow', async ({ step }) => {
         await step.run('step-1', async () => 'result-1');

--- a/src/engine.test.ts
+++ b/src/engine.test.ts
@@ -1203,7 +1203,7 @@ describe('WorkflowEngine', () => {
           status: WorkflowStatus.RUNNING,
         });
 
-        await testBoss.send('workflow-run-stuck', {
+        await testBoss.send('workflow_run_dlq', {
           runId,
           resourceId,
           workflowId: 'test-workflow',
@@ -1230,7 +1230,7 @@ describe('WorkflowEngine', () => {
           status: WorkflowStatus.RUNNING,
         });
 
-        await testBoss.send('workflow-run-stuck', {
+        await testBoss.send('workflow_run_dlq', {
           runId,
           resourceId,
           workflowId: 'test-workflow',
@@ -1255,7 +1255,7 @@ describe('WorkflowEngine', () => {
           status: WorkflowStatus.COMPLETED,
         });
 
-        await testBoss.send('workflow-run-stuck', {
+        await testBoss.send('workflow_run_dlq', {
           runId,
           resourceId,
           workflowId: 'test-workflow',

--- a/src/engine.test.ts
+++ b/src/engine.test.ts
@@ -1160,7 +1160,7 @@ describe('WorkflowEngine', () => {
       expect(finished.output).toEqual({ value: 'first+second' });
     });
 
-    it('should use exponential backoff for retries', async () => {
+    it('should delegate retries to pg-boss with exponential backoff', async () => {
       const failingWorkflow = workflow('backoff-workflow', async ({ step }) => {
         await step.run('step-1', async () => {
           throw new Error('always fails');
@@ -1178,6 +1178,26 @@ describe('WorkflowEngine', () => {
         options: { retries: 2 },
       });
 
+      // pg-boss handles retries internally, so only ONE boss.send call is
+      // made — the retry options on it tell pg-boss to retry up to 2 times
+      // with exponential backoff.
+      type JobData = { runId: string; workflowId: string };
+      const sentCalls = sendSpy.mock.calls.filter(
+        ([queue, data]) =>
+          queue === WORKFLOW_RUN_QUEUE_NAME &&
+          (data as JobData).runId === run.id &&
+          (data as JobData).workflowId === 'backoff-workflow',
+      );
+      expect(sentCalls.length).toBe(1);
+      const opts = sentCalls[0][2] as {
+        retryLimit?: number;
+        retryBackoff?: boolean;
+        retryDelay?: number;
+      };
+      expect(opts.retryLimit).toBe(2);
+      expect(opts.retryBackoff).toBe(true);
+      expect(opts.retryDelay).toBe(1);
+
       await expect
         .poll(async () => (await engine.getRun({ runId: run.id, resourceId })).status, {
           timeout: 10000,
@@ -1187,24 +1207,6 @@ describe('WorkflowEngine', () => {
       const finalRun = await engine.getRun({ runId: run.id, resourceId });
       expect(finalRun.retryCount).toBe(2);
       expect(finalRun.error).toBe('always fails');
-
-      type JobData = { runId: string; workflowId: string };
-
-      const retryCalls = sendSpy.mock.calls.filter(
-        ([queue, data]) =>
-          queue === WORKFLOW_RUN_QUEUE_NAME &&
-          (data as JobData).runId === run.id &&
-          (data as JobData).workflowId === 'backoff-workflow',
-      );
-
-      // 1 initial send from startWorkflow + 2 retry sends
-      expect(retryCalls.length).toBe(3);
-
-      for (const [, , options] of retryCalls.slice(1)) {
-        const opts = options as { startAfter?: Date; retryDelay?: number };
-        expect(opts.startAfter).toBeInstanceOf(Date);
-        expect(opts).not.toHaveProperty('retryDelay');
-      }
 
       sendSpy.mockRestore();
     });
@@ -1245,34 +1247,7 @@ describe('WorkflowEngine', () => {
         return runId;
       };
 
-      it('should retry a stuck RUNNING run when retries are available', async () => {
-        const runId = await insertStuckRun({
-          workflowId: 'test-workflow',
-          retryCount: 0,
-          maxRetries: 3,
-          status: WorkflowStatus.RUNNING,
-        });
-
-        await testBoss.send(WORKFLOW_RUN_DLQ_QUEUE_NAME, {
-          runId,
-          resourceId,
-          workflowId: 'test-workflow',
-          input: { data: 'stuck' },
-        });
-
-        // The DLQ worker should bump retryCount and re-enqueue, then the main
-        // worker picks it up and completes the workflow.
-        await expect
-          .poll(async () => (await engine.getRun({ runId, resourceId })).status, {
-            timeout: 10000,
-          })
-          .toBe(WorkflowStatus.COMPLETED);
-
-        const recovered = await engine.getRun({ runId, resourceId });
-        expect(recovered.retryCount).toBeGreaterThanOrEqual(1);
-      });
-
-      it('should mark a stuck RUNNING run as FAILED when retries are exhausted', async () => {
+      it('should mark a stuck RUNNING run as FAILED when DLQ fires', async () => {
         const runId = await insertStuckRun({
           workflowId: 'test-workflow',
           retryCount: 2,
@@ -1352,10 +1327,10 @@ describe('WorkflowEngine', () => {
         });
 
         await expect
-          .poll(async () => (await engine.getRun({ runId: liveRunId, resourceId })).retryCount, {
+          .poll(async () => (await engine.getRun({ runId: liveRunId, resourceId })).status, {
             timeout: 10000,
           })
-          .toBeGreaterThanOrEqual(1);
+          .toBe(WorkflowStatus.FAILED);
       });
     });
 

--- a/src/engine.test.ts
+++ b/src/engine.test.ts
@@ -3,6 +3,7 @@ import type { PgBoss } from 'pg-boss';
 import * as v from 'valibot';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
+import { WORKFLOW_RUN_DLQ_QUEUE_NAME, WORKFLOW_RUN_QUEUE_NAME } from './constants';
 import { workflow } from './definition';
 import { WorkflowEngine } from './engine';
 import { WorkflowEngineError, WorkflowRunNotFoundError } from './error';
@@ -1191,7 +1192,7 @@ describe('WorkflowEngine', () => {
 
       const retryCalls = sendSpy.mock.calls.filter(
         ([queue, data]) =>
-          queue === 'workflow-run' &&
+          queue === WORKFLOW_RUN_QUEUE_NAME &&
           (data as JobData).runId === run.id &&
           (data as JobData).workflowId === 'backoff-workflow',
       );
@@ -1252,7 +1253,7 @@ describe('WorkflowEngine', () => {
           status: WorkflowStatus.RUNNING,
         });
 
-        await testBoss.send('workflow_run_dlq', {
+        await testBoss.send(WORKFLOW_RUN_DLQ_QUEUE_NAME, {
           runId,
           resourceId,
           workflowId: 'test-workflow',
@@ -1279,7 +1280,7 @@ describe('WorkflowEngine', () => {
           status: WorkflowStatus.RUNNING,
         });
 
-        await testBoss.send('workflow_run_dlq', {
+        await testBoss.send(WORKFLOW_RUN_DLQ_QUEUE_NAME, {
           runId,
           resourceId,
           workflowId: 'test-workflow',
@@ -1304,7 +1305,7 @@ describe('WorkflowEngine', () => {
           status: WorkflowStatus.COMPLETED,
         });
 
-        await testBoss.send('workflow_run_dlq', {
+        await testBoss.send(WORKFLOW_RUN_DLQ_QUEUE_NAME, {
           runId,
           resourceId,
           workflowId: 'test-workflow',
@@ -1322,13 +1323,13 @@ describe('WorkflowEngine', () => {
       it('should silently no-op for DLQ jobs with missing or unknown runId', async () => {
         // The DLQ worker must not crash on malformed/orphaned messages,
         // otherwise a single bad payload poisons the entire DLQ pipeline.
-        await testBoss.send('workflow_run_dlq', {
+        await testBoss.send(WORKFLOW_RUN_DLQ_QUEUE_NAME, {
           resourceId,
           workflowId: 'test-workflow',
           input: {},
         });
 
-        await testBoss.send('workflow_run_dlq', {
+        await testBoss.send(WORKFLOW_RUN_DLQ_QUEUE_NAME, {
           runId: 'run_does_not_exist_xyz',
           resourceId,
           workflowId: 'test-workflow',
@@ -1343,7 +1344,7 @@ describe('WorkflowEngine', () => {
           maxRetries: 3,
           status: WorkflowStatus.RUNNING,
         });
-        await testBoss.send('workflow_run_dlq', {
+        await testBoss.send(WORKFLOW_RUN_DLQ_QUEUE_NAME, {
           runId: liveRunId,
           resourceId,
           workflowId: 'test-workflow',

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -102,6 +102,13 @@ const defaultExpireInSeconds = process.env.WORKFLOW_RUN_EXPIRE_IN_SECONDS
   ? Number.parseInt(process.env.WORKFLOW_RUN_EXPIRE_IN_SECONDS, 10)
   : 5 * 60; // 5 minutes
 
+// pg-boss workers auto-touch heartbeat_on every heartbeatSeconds / 2 seconds
+// while the process is alive. If the worker dies, heartbeats stop and pg-boss's
+// monitor (~60s ticks) routes the job to the dead-letter queue. Minimum is 10.
+const defaultHeartbeatSeconds = process.env.WORKFLOW_RUN_HEARTBEAT_SECONDS
+  ? Number.parseInt(process.env.WORKFLOW_RUN_HEARTBEAT_SECONDS, 10)
+  : 30;
+
 export class WorkflowEngine {
   private boss: PgBoss;
   private db: Db;
@@ -174,10 +181,14 @@ export class WorkflowEngine {
 
     // retryLimit: 0 disables pg-boss's built-in retries so the engine fully
     // owns retry logic. Any failure (including timeout from a dead worker)
-    // immediately routes the job to the dead-letter queue.
+    // immediately routes the job to the dead-letter queue. heartbeatSeconds
+    // makes pg-boss workers auto-touch the job while alive; if the process
+    // dies, the missed heartbeats trigger DLQ routing in ~heartbeatSeconds
+    // + monitorInterval (≈60s) instead of waiting for the full expireInSeconds.
     await this.boss.createQueue(WORKFLOW_RUN_QUEUE_NAME, {
       retryLimit: 0,
       deadLetter: STUCK_WORKFLOW_RUN_QUEUE_NAME,
+      heartbeatSeconds: defaultHeartbeatSeconds,
     });
 
     // createQueue is a no-op for existing queues, so explicitly update
@@ -185,6 +196,7 @@ export class WorkflowEngine {
     await this.boss.updateQueue(WORKFLOW_RUN_QUEUE_NAME, {
       retryLimit: 0,
       deadLetter: STUCK_WORKFLOW_RUN_QUEUE_NAME,
+      heartbeatSeconds: defaultHeartbeatSeconds,
     });
 
     const numWorkers: number = +(process.env.WORKFLOW_RUN_WORKERS ?? 3);

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -171,55 +171,42 @@ export class WorkflowEngine {
       }
     }
 
-    // Dead-letter queue for jobs whose worker died or that pg-boss marked
-    // failed after the expireInSeconds timeout. The DLQ worker reconciles
-    // the orphaned workflow_runs row (retry with backoff or mark FAILED)
-    // so it never gets stuck in RUNNING state forever.
-    await this.boss.createQueue(WORKFLOW_RUN_DLQ_QUEUE_NAME, {
-      retryLimit: 0,
-    });
-
-    // retryLimit: 0 makes the engine the sole authority on retry policy.
-    // The engine tracks attempts on workflow_runs.retryCount/maxRetries and
-    // re-enqueues with its own exponential backoff (see handleWorkflowRun).
-    // If pg-boss also retried (default 2), a single failure would burn
-    // pg-boss retries without the engine's bookkeeping ever seeing them —
-    // retryCount would stay at 0 while pg-boss silently retried under its
-    // own backoff, drifting workflow_runs.status out of sync with the queue.
-    // With retryLimit: 0, any failure (thrown error, expired job from a
-    // dead worker, missed heartbeats) routes straight to workflow_run_dlq
-    // where handleStuckWorkflowRun reconciles the run against the canonical
-    // workflow_runs row and decides retry-vs-fail. heartbeatSeconds makes
-    // pg-boss workers auto-touch the job while alive; if the process dies,
-    // missed heartbeats trigger DLQ routing in ~heartbeatSeconds +
-    // monitorInterval (≈60s) instead of waiting for the full expireInSeconds.
-    await this.boss.createQueue(WORKFLOW_RUN_QUEUE_NAME, {
+    // The engine owns retry policy via workflow_runs.retryCount, so pg-boss
+    // must not retry on its own — otherwise its silent retries would drift
+    // retryCount/status out of sync with the queue. retryLimit: 0 routes any
+    // failure (thrown error, expired job, missed heartbeats) straight to the
+    // DLQ where handleStuckWorkflowRun reconciles the run. heartbeatSeconds
+    // lets pg-boss detect dead workers in ~heartbeatSeconds + monitorInterval
+    // (≈60s) instead of waiting for the full expireInSeconds.
+    const mainQueueOptions = {
       retryLimit: 0,
       deadLetter: WORKFLOW_RUN_DLQ_QUEUE_NAME,
       heartbeatSeconds: defaultHeartbeatSeconds,
-    });
-
-    // createQueue is a no-op for existing queues, so explicitly update
-    // settings to ensure installations that predate the DLQ pick it up.
-    await this.boss.updateQueue(WORKFLOW_RUN_QUEUE_NAME, {
-      retryLimit: 0,
-      deadLetter: WORKFLOW_RUN_DLQ_QUEUE_NAME,
-      heartbeatSeconds: defaultHeartbeatSeconds,
-    });
+    };
+    await this.boss.createQueue(WORKFLOW_RUN_DLQ_QUEUE_NAME, { retryLimit: 0 });
+    await this.boss.createQueue(WORKFLOW_RUN_QUEUE_NAME, mainQueueOptions);
+    // createQueue is a no-op for existing queues; updateQueue ensures
+    // installations that predate the DLQ adopt these settings on next start.
+    await this.boss.updateQueue(WORKFLOW_RUN_QUEUE_NAME, mainQueueOptions);
 
     const numWorkers: number = +(process.env.WORKFLOW_RUN_WORKERS ?? 3);
 
     if (asEngine) {
-      for (let i = 0; i < numWorkers; i++) {
-        await this.boss.work<WorkflowRunJobParameters>(
-          WORKFLOW_RUN_QUEUE_NAME,
-          { pollingIntervalSeconds: 0.5, batchSize },
-          (job) => this.handleWorkflowRun(job),
-        );
-        this.logger.log(
-          `Worker ${i + 1}/${numWorkers} started for queue ${WORKFLOW_RUN_QUEUE_NAME}`,
-        );
-      }
+      await Promise.all(
+        Array.from({ length: numWorkers }, (_, i) =>
+          this.boss
+            .work<WorkflowRunJobParameters>(
+              WORKFLOW_RUN_QUEUE_NAME,
+              { pollingIntervalSeconds: 0.5, batchSize },
+              (job) => this.handleWorkflowRun(job),
+            )
+            .then(() => {
+              this.logger.log(
+                `Worker ${i + 1}/${numWorkers} started for queue ${WORKFLOW_RUN_QUEUE_NAME}`,
+              );
+            }),
+        ),
+      );
 
       await this.boss.work<WorkflowRunJobParameters>(
         WORKFLOW_RUN_DLQ_QUEUE_NAME,
@@ -988,34 +975,7 @@ export class WorkflowEngine {
         });
       }
     } catch (error) {
-      if (run && run.retryCount < run.maxRetries) {
-        await this.updateRun({
-          runId,
-          resourceId: scopedResourceId,
-          data: {
-            retryCount: run.retryCount + 1,
-            jobId: job?.id,
-          },
-        });
-
-        const retryDelay = 2 ** run.retryCount * 1000;
-
-        // Re-enqueue with engine-controlled backoff. The queue is configured
-        // with retryLimit: 0 so pg-boss never retries on its own — retries
-        // always flow through this path (or via workflow_run_dlq when a
-        // worker dies before this catch block can run), keeping
-        // workflow_runs.retryCount in sync with the queue.
-        const pgBossJob: WorkflowRunJobParameters = {
-          runId,
-          resourceId: scopedResourceId,
-          workflowId,
-          input,
-        };
-        await this.boss?.send('workflow-run', pgBossJob, {
-          startAfter: new Date(Date.now() + retryDelay),
-          expireInSeconds: defaultExpireInSeconds,
-        });
-
+      if (run && (await this.enqueueRetry(run, { workflowId, input, jobId: job?.id }))) {
         return;
       }
 
@@ -1037,6 +997,41 @@ export class WorkflowEngine {
   }
 
   /**
+   * Schedules the next attempt for a workflow run using the engine's
+   * exponential backoff. Returns true if a retry was enqueued, false when
+   * retries are exhausted — callers decide how to mark FAILED.
+   */
+  private async enqueueRetry(
+    run: WorkflowRun,
+    { workflowId, input, jobId }: { workflowId: string; input: unknown; jobId?: string },
+  ): Promise<boolean> {
+    if (run.retryCount >= run.maxRetries) {
+      return false;
+    }
+
+    const scopedResourceId = run.resourceId ?? undefined;
+    await this.updateRun({
+      runId: run.id,
+      resourceId: scopedResourceId,
+      data: {
+        retryCount: run.retryCount + 1,
+        ...(jobId ? { jobId } : {}),
+      },
+    });
+
+    const retryDelay = 2 ** run.retryCount * 1000;
+    await this.boss.send(
+      WORKFLOW_RUN_QUEUE_NAME,
+      { runId: run.id, resourceId: scopedResourceId, workflowId, input },
+      {
+        startAfter: new Date(Date.now() + retryDelay),
+        expireInSeconds: defaultExpireInSeconds,
+      },
+    );
+    return true;
+  }
+
+  /**
    * Reconciles workflow runs whose worker died mid-execution. pg-boss routes
    * jobs that time out (or otherwise fail without the handler running to
    * completion) to the dead-letter queue, with the original job payload
@@ -1045,50 +1040,18 @@ export class WorkflowEngine {
    * FAILED if retries are exhausted.
    */
   private async handleStuckWorkflowRun([job]: Job<WorkflowRunJobParameters>[]) {
-    const { runId, resourceId, workflowId, input } = job?.data ?? {};
+    const { runId, workflowId, input } = job?.data ?? {};
+    if (!runId) return;
 
-    if (!runId) {
-      return;
-    }
+    const run = await getWorkflowRun({ runId }, { db: this.db });
+    if (!run || run.status !== WorkflowStatus.RUNNING) return;
 
-    let run: WorkflowRun;
-    try {
-      run = await this.getRun({ runId });
-    } catch (error) {
-      if (error instanceof WorkflowRunNotFoundError) {
-        return;
-      }
-      throw error;
-    }
+    const retried = await this.enqueueRetry(run, {
+      workflowId: workflowId ?? run.workflowId,
+      input: input ?? run.input,
+    });
 
-    // Only RUNNING runs are stuck. Terminal states (completed/failed/cancelled)
-    // and PAUSED runs need no recovery — a failed catch handler will have
-    // already marked the run FAILED, and a paused run isn't waiting on this job.
-    if (run.status !== WorkflowStatus.RUNNING) {
-      return;
-    }
-
-    const scopedResourceId = this.resolveScopedResourceId(resourceId, run);
-
-    if (run.retryCount < run.maxRetries) {
-      await this.updateRun({
-        runId,
-        resourceId: scopedResourceId,
-        data: { retryCount: run.retryCount + 1 },
-      });
-
-      const retryDelay = 2 ** run.retryCount * 1000;
-      const retryJob: WorkflowRunJobParameters = {
-        runId,
-        resourceId: scopedResourceId,
-        workflowId: workflowId ?? run.workflowId,
-        input: input ?? run.input,
-      };
-      await this.boss.send(WORKFLOW_RUN_QUEUE_NAME, retryJob, {
-        startAfter: new Date(Date.now() + retryDelay),
-        expireInSeconds: defaultExpireInSeconds,
-      });
-
+    if (retried) {
       this.logger.log(
         `Retrying stuck workflow run (attempt ${run.retryCount + 1}/${run.maxRetries})`,
         { runId, workflowId: run.workflowId },
@@ -1098,7 +1061,7 @@ export class WorkflowEngine {
 
     await this.updateRun({
       runId,
-      resourceId: scopedResourceId,
+      resourceId: run.resourceId ?? undefined,
       data: {
         status: WorkflowStatus.FAILED,
         error: 'Workflow run worker died or job expired before completion',

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -5,7 +5,7 @@ import { parseWorkflowHandler } from './ast-parser';
 import {
   DEFAULT_PGBOSS_SCHEMA,
   PAUSE_EVENT_NAME,
-  STUCK_WORKFLOW_RUN_QUEUE_NAME,
+  WORKFLOW_RUN_DLQ_QUEUE_NAME,
   WORKFLOW_RUN_QUEUE_NAME,
 } from './constants';
 import { runMigrations } from './db/migration';
@@ -175,7 +175,7 @@ export class WorkflowEngine {
     // failed after the expireInSeconds timeout. The DLQ worker reconciles
     // the orphaned workflow_runs row (retry with backoff or mark FAILED)
     // so it never gets stuck in RUNNING state forever.
-    await this.boss.createQueue(STUCK_WORKFLOW_RUN_QUEUE_NAME, {
+    await this.boss.createQueue(WORKFLOW_RUN_DLQ_QUEUE_NAME, {
       retryLimit: 0,
     });
 
@@ -187,7 +187,7 @@ export class WorkflowEngine {
     // + monitorInterval (≈60s) instead of waiting for the full expireInSeconds.
     await this.boss.createQueue(WORKFLOW_RUN_QUEUE_NAME, {
       retryLimit: 0,
-      deadLetter: STUCK_WORKFLOW_RUN_QUEUE_NAME,
+      deadLetter: WORKFLOW_RUN_DLQ_QUEUE_NAME,
       heartbeatSeconds: defaultHeartbeatSeconds,
     });
 
@@ -195,7 +195,7 @@ export class WorkflowEngine {
     // settings to ensure installations that predate the DLQ pick it up.
     await this.boss.updateQueue(WORKFLOW_RUN_QUEUE_NAME, {
       retryLimit: 0,
-      deadLetter: STUCK_WORKFLOW_RUN_QUEUE_NAME,
+      deadLetter: WORKFLOW_RUN_DLQ_QUEUE_NAME,
       heartbeatSeconds: defaultHeartbeatSeconds,
     });
 
@@ -214,11 +214,11 @@ export class WorkflowEngine {
       }
 
       await this.boss.work<WorkflowRunJobParameters>(
-        STUCK_WORKFLOW_RUN_QUEUE_NAME,
+        WORKFLOW_RUN_DLQ_QUEUE_NAME,
         { pollingIntervalSeconds: 0.5, batchSize: 1 },
         (job) => this.handleStuckWorkflowRun(job),
       );
-      this.logger.log(`Worker started for queue ${STUCK_WORKFLOW_RUN_QUEUE_NAME}`);
+      this.logger.log(`Worker started for queue ${WORKFLOW_RUN_DLQ_QUEUE_NAME}`);
     }
 
     this._started = true;

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -187,7 +187,7 @@ export class WorkflowEngine {
     // per-job from the workflow's `retries` option. Failures (thrown error,
     // expired job, missed heartbeats) re-enqueue automatically; once a job's
     // retries are exhausted, pg-boss routes it to the DLQ where
-    // handleStuckWorkflowRun marks the run FAILED. heartbeatSeconds lets
+    // handleWorkflowRunDlq marks the run FAILED. heartbeatSeconds lets
     // pg-boss detect dead workers in ~heartbeatSeconds + monitorInterval
     // (≈60s) instead of waiting for the full expireInSeconds.
     const mainQueueOptions = {
@@ -225,7 +225,7 @@ export class WorkflowEngine {
       await this.boss.work<WorkflowRunJobParameters>(
         WORKFLOW_RUN_DLQ_QUEUE_NAME,
         { pollingIntervalSeconds: 0.5, batchSize: 1 },
-        (jobs) => this.handleStuckWorkflowRun(jobs),
+        (jobs) => this.handleWorkflowRunDlq(jobs),
       );
       this.logger.log(`Worker started for queue ${WORKFLOW_RUN_DLQ_QUEUE_NAME}`);
     }
@@ -1027,7 +1027,7 @@ export class WorkflowEngine {
    * we mark it FAILED with whatever error message the catch block last
    * persisted, falling back to a worker-death message.
    */
-  private async handleStuckWorkflowRun([job]: { data?: WorkflowRunJobParameters }[]) {
+  private async handleWorkflowRunDlq([job]: { data?: WorkflowRunJobParameters }[]) {
     const { runId } = job?.data ?? {};
     if (!runId) return;
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1,6 +1,6 @@
 import { merge } from 'es-toolkit';
 import pg from 'pg';
-import { type Db, type Job, PgBoss } from 'pg-boss';
+import { type Db, type JobWithMetadata, PgBoss } from 'pg-boss';
 import { parseWorkflowHandler } from './ast-parser';
 import {
   DEFAULT_PGBOSS_SCHEMA,
@@ -102,6 +102,15 @@ const defaultExpireInSeconds = process.env.WORKFLOW_RUN_EXPIRE_IN_SECONDS
   ? Number.parseInt(process.env.WORKFLOW_RUN_EXPIRE_IN_SECONDS, 10)
   : 5 * 60; // 5 minutes
 
+// retryDelay is the base for pg-boss's exponential backoff:
+// `retryDelay * 2^retryCount` seconds (with up to ±50% jitter), so a base
+// of 1 second yields ~1s, ~2s, ~4s, ~8s, … between attempts.
+const retrySendOptions = (maxRetries: number) => ({
+  retryLimit: maxRetries,
+  retryBackoff: true,
+  retryDelay: 1,
+});
+
 // pg-boss workers auto-touch heartbeat_on every heartbeatSeconds / 2 seconds
 // while the process is alive. If the worker dies, heartbeats stop and pg-boss's
 // monitor (~60s ticks) routes the job to the dead-letter queue. Minimum is 10.
@@ -174,12 +183,12 @@ export class WorkflowEngine {
       }
     }
 
-    // The engine owns retry policy via workflow_runs.retryCount, so pg-boss
-    // must not retry on its own — otherwise its silent retries would drift
-    // retryCount/status out of sync with the queue. retryLimit: 0 routes any
-    // failure (thrown error, expired job, missed heartbeats) straight to the
-    // DLQ where handleStuckWorkflowRun reconciles the run. heartbeatSeconds
-    // lets pg-boss detect dead workers in ~heartbeatSeconds + monitorInterval
+    // pg-boss handles retries: every send sets retryLimit + retryBackoff
+    // per-job from the workflow's `retries` option. Failures (thrown error,
+    // expired job, missed heartbeats) re-enqueue automatically; once a job's
+    // retries are exhausted, pg-boss routes it to the DLQ where
+    // handleStuckWorkflowRun marks the run FAILED. heartbeatSeconds lets
+    // pg-boss detect dead workers in ~heartbeatSeconds + monitorInterval
     // (≈60s) instead of waiting for the full expireInSeconds.
     const mainQueueOptions = {
       retryLimit: 0,
@@ -195,13 +204,15 @@ export class WorkflowEngine {
     const numWorkers: number = +(process.env.WORKFLOW_RUN_WORKERS ?? 3);
 
     if (asEngine) {
+      // includeMetadata exposes job.retryCount so we can mirror pg-boss's
+      // attempt counter into workflow_runs.retryCount.
       await Promise.all(
         Array.from({ length: numWorkers }, (_, i) =>
           this.boss
             .work<WorkflowRunJobParameters>(
               WORKFLOW_RUN_QUEUE_NAME,
-              { pollingIntervalSeconds: 0.5, batchSize },
-              (job) => this.handleWorkflowRun(job),
+              { pollingIntervalSeconds: 0.5, batchSize, includeMetadata: true },
+              (jobs) => this.handleWorkflowRun(jobs),
             )
             .then(() => {
               this.logger.log(
@@ -214,7 +225,7 @@ export class WorkflowEngine {
       await this.boss.work<WorkflowRunJobParameters>(
         WORKFLOW_RUN_DLQ_QUEUE_NAME,
         { pollingIntervalSeconds: 0.5, batchSize: 1 },
-        (job) => this.handleStuckWorkflowRun(job),
+        (jobs) => this.handleStuckWorkflowRun(jobs),
       );
       this.logger.log(`Worker started for queue ${WORKFLOW_RUN_DLQ_QUEUE_NAME}`);
     }
@@ -395,6 +406,7 @@ export class WorkflowEngine {
           await this.boss.send(WORKFLOW_RUN_QUEUE_NAME, job, {
             startAfter: new Date(),
             expireInSeconds: options?.expireInSeconds ?? defaultExpireInSeconds,
+            ...retrySendOptions(insertedRun.maxRetries),
           });
         }
 
@@ -597,6 +609,7 @@ export class WorkflowEngine {
 
     await this.boss.send(WORKFLOW_RUN_QUEUE_NAME, job, {
       expireInSeconds: options?.expireInSeconds ?? defaultExpireInSeconds,
+      ...retrySendOptions(run.maxRetries),
     });
 
     this.logger.log(`event ${eventName} sent for workflow run with id ${runId}`);
@@ -729,8 +742,8 @@ export class WorkflowEngine {
     return run.resourceId ?? undefined;
   }
 
-  private async handleWorkflowRun([job]: Job<WorkflowRunJobParameters>[]) {
-    const { runId = '', resourceId, workflowId = '', input, event } = job?.data ?? {};
+  private async handleWorkflowRun([job]: JobWithMetadata<WorkflowRunJobParameters>[]) {
+    const { runId = '', resourceId, workflowId = '', event } = job?.data ?? {};
 
     let run: WorkflowRun | undefined;
     let scopedResourceId: string | undefined;
@@ -769,6 +782,17 @@ export class WorkflowEngine {
       }
 
       scopedResourceId = this.resolveScopedResourceId(resourceId, run);
+
+      // Mirror pg-boss's attempt counter so workflow_runs.retryCount stays
+      // observable to API consumers across retries.
+      if (job?.retryCount !== undefined && run.retryCount !== job.retryCount) {
+        await this.updateRun({
+          runId,
+          resourceId: scopedResourceId,
+          data: { retryCount: job.retryCount },
+        });
+        run = { ...run, retryCount: job.retryCount };
+      }
 
       if (run.status === WorkflowStatus.CANCELLED) {
         this.logger.log(`Workflow run ${runId} is cancelled, skipping`);
@@ -978,17 +1002,14 @@ export class WorkflowEngine {
         });
       }
     } catch (error) {
-      if (run && (await this.enqueueRetry(run, { workflowId, input, jobId: job?.id }))) {
-        return;
-      }
-
-      // TODO: Ensure that this code always runs, even if worker is stopped unexpectedly.
+      // Persist the error so the DLQ handler can surface it after retries
+      // are exhausted. pg-boss handles the retry-vs-DLQ decision based on
+      // the per-job retryLimit set when the job was enqueued.
       if (runId) {
         await this.updateRun({
           runId,
           resourceId: scopedResourceId,
           data: {
-            status: WorkflowStatus.FAILED,
             error: error instanceof Error ? error.message : String(error),
             jobId: job?.id,
           },
@@ -1000,74 +1021,25 @@ export class WorkflowEngine {
   }
 
   /**
-   * Schedules the next attempt for a workflow run using the engine's
-   * exponential backoff. Returns true if a retry was enqueued, false when
-   * retries are exhausted — callers decide how to mark FAILED.
+   * Reconciles workflow runs whose retries pg-boss has exhausted (handler
+   * threw on the final attempt, or worker died and missed the heartbeat
+   * past the retry budget). The DLQ entry tells us the run is unrecoverable;
+   * we mark it FAILED with whatever error message the catch block last
+   * persisted, falling back to a worker-death message.
    */
-  private async enqueueRetry(
-    run: WorkflowRun,
-    { workflowId, input, jobId }: { workflowId: string; input: unknown; jobId?: string },
-  ): Promise<boolean> {
-    if (run.retryCount >= run.maxRetries) {
-      return false;
-    }
-
-    const scopedResourceId = run.resourceId ?? undefined;
-    await this.updateRun({
-      runId: run.id,
-      resourceId: scopedResourceId,
-      data: {
-        retryCount: run.retryCount + 1,
-        ...(jobId ? { jobId } : {}),
-      },
-    });
-
-    const retryDelay = 2 ** run.retryCount * 1000;
-    await this.boss.send(
-      WORKFLOW_RUN_QUEUE_NAME,
-      { runId: run.id, resourceId: scopedResourceId, workflowId, input },
-      {
-        startAfter: new Date(Date.now() + retryDelay),
-        expireInSeconds: defaultExpireInSeconds,
-      },
-    );
-    return true;
-  }
-
-  /**
-   * Reconciles workflow runs whose worker died mid-execution. pg-boss routes
-   * jobs that time out (or otherwise fail without the handler running to
-   * completion) to the dead-letter queue, with the original job payload
-   * preserved. We use that payload to find the orphaned workflow_runs row
-   * and either retry it with the engine's exponential backoff or mark it
-   * FAILED if retries are exhausted.
-   */
-  private async handleStuckWorkflowRun([job]: Job<WorkflowRunJobParameters>[]) {
-    const { runId, workflowId, input } = job?.data ?? {};
+  private async handleStuckWorkflowRun([job]: { data?: WorkflowRunJobParameters }[]) {
+    const { runId } = job?.data ?? {};
     if (!runId) return;
 
     const run = await getWorkflowRun({ runId }, { db: this.db });
     if (!run || run.status !== WorkflowStatus.RUNNING) return;
-
-    const retried = await this.enqueueRetry(run, {
-      workflowId: workflowId ?? run.workflowId,
-      input: input ?? run.input,
-    });
-
-    if (retried) {
-      this.logger.log(
-        `Retrying stuck workflow run (attempt ${run.retryCount + 1}/${run.maxRetries})`,
-        { runId, workflowId: run.workflowId },
-      );
-      return;
-    }
 
     await this.updateRun({
       runId,
       resourceId: run.resourceId ?? undefined,
       data: {
         status: WorkflowStatus.FAILED,
-        error: 'Workflow run worker died or job expired before completion',
+        error: run.error ?? 'Workflow run worker died or job expired before completion',
       },
     });
 
@@ -1272,6 +1244,7 @@ export class WorkflowEngine {
         await this.boss.send(WORKFLOW_RUN_QUEUE_NAME, job, {
           startAfter: timeoutDate.getTime() <= Date.now() ? new Date() : timeoutDate,
           expireInSeconds: defaultExpireInSeconds,
+          ...retrySendOptions(run.maxRetries),
         });
       } catch (error) {
         // Revert PAUSED status so the workflow can retry this step
@@ -1466,6 +1439,7 @@ export class WorkflowEngine {
         {
           startAfter: new Date(Date.now() + intervalMs),
           expireInSeconds: defaultExpireInSeconds,
+          ...retrySendOptions(run.maxRetries),
         },
       );
     } catch (error) {

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -154,7 +154,10 @@ export class WorkflowEngine {
 
   async start(
     asEngine = true,
-    { batchSize }: { batchSize?: number } = { batchSize: 1 },
+    {
+      batchSize = 1,
+      heartbeatSeconds = defaultHeartbeatSeconds,
+    }: { batchSize?: number; heartbeatSeconds?: number } = {},
   ): Promise<void> {
     if (this._started) {
       return;
@@ -181,7 +184,7 @@ export class WorkflowEngine {
     const mainQueueOptions = {
       retryLimit: 0,
       deadLetter: WORKFLOW_RUN_DLQ_QUEUE_NAME,
-      heartbeatSeconds: defaultHeartbeatSeconds,
+      heartbeatSeconds,
     };
     await this.boss.createQueue(WORKFLOW_RUN_DLQ_QUEUE_NAME, { retryLimit: 0 });
     await this.boss.createQueue(WORKFLOW_RUN_QUEUE_NAME, mainQueueOptions);

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -179,12 +179,20 @@ export class WorkflowEngine {
       retryLimit: 0,
     });
 
-    // retryLimit: 0 disables pg-boss's built-in retries so the engine fully
-    // owns retry logic. Any failure (including timeout from a dead worker)
-    // immediately routes the job to the dead-letter queue. heartbeatSeconds
-    // makes pg-boss workers auto-touch the job while alive; if the process
-    // dies, the missed heartbeats trigger DLQ routing in ~heartbeatSeconds
-    // + monitorInterval (≈60s) instead of waiting for the full expireInSeconds.
+    // retryLimit: 0 makes the engine the sole authority on retry policy.
+    // The engine tracks attempts on workflow_runs.retryCount/maxRetries and
+    // re-enqueues with its own exponential backoff (see handleWorkflowRun).
+    // If pg-boss also retried (default 2), a single failure would burn
+    // pg-boss retries without the engine's bookkeeping ever seeing them —
+    // retryCount would stay at 0 while pg-boss silently retried under its
+    // own backoff, drifting workflow_runs.status out of sync with the queue.
+    // With retryLimit: 0, any failure (thrown error, expired job from a
+    // dead worker, missed heartbeats) routes straight to workflow_run_dlq
+    // where handleStuckWorkflowRun reconciles the run against the canonical
+    // workflow_runs row and decides retry-vs-fail. heartbeatSeconds makes
+    // pg-boss workers auto-touch the job while alive; if the process dies,
+    // missed heartbeats trigger DLQ routing in ~heartbeatSeconds +
+    // monitorInterval (≈60s) instead of waiting for the full expireInSeconds.
     await this.boss.createQueue(WORKFLOW_RUN_QUEUE_NAME, {
       retryLimit: 0,
       deadLetter: WORKFLOW_RUN_DLQ_QUEUE_NAME,
@@ -992,7 +1000,11 @@ export class WorkflowEngine {
 
         const retryDelay = 2 ** run.retryCount * 1000;
 
-        // NOTE: Do not use pg-boss retryLimit and retryBackoff so that we can fully control the retry logic from the WorkflowEngine and not PGBoss.
+        // Re-enqueue with engine-controlled backoff. The queue is configured
+        // with retryLimit: 0 so pg-boss never retries on its own — retries
+        // always flow through this path (or via workflow_run_dlq when a
+        // worker dies before this catch block can run), keeping
+        // workflow_runs.retryCount in sync with the queue.
         const pgBossJob: WorkflowRunJobParameters = {
           runId,
           resourceId: scopedResourceId,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -2,7 +2,12 @@ import { merge } from 'es-toolkit';
 import pg from 'pg';
 import { type Db, type Job, PgBoss } from 'pg-boss';
 import { parseWorkflowHandler } from './ast-parser';
-import { DEFAULT_PGBOSS_SCHEMA, PAUSE_EVENT_NAME, WORKFLOW_RUN_QUEUE_NAME } from './constants';
+import {
+  DEFAULT_PGBOSS_SCHEMA,
+  PAUSE_EVENT_NAME,
+  STUCK_WORKFLOW_RUN_QUEUE_NAME,
+  WORKFLOW_RUN_QUEUE_NAME,
+} from './constants';
 import { runMigrations } from './db/migration';
 import {
   getWorkflowRun,
@@ -159,7 +164,28 @@ export class WorkflowEngine {
       }
     }
 
-    await this.boss.createQueue(WORKFLOW_RUN_QUEUE_NAME);
+    // Dead-letter queue for jobs whose worker died or that pg-boss marked
+    // failed after the expireInSeconds timeout. The DLQ worker reconciles
+    // the orphaned workflow_runs row (retry with backoff or mark FAILED)
+    // so it never gets stuck in RUNNING state forever.
+    await this.boss.createQueue(STUCK_WORKFLOW_RUN_QUEUE_NAME, {
+      retryLimit: 0,
+    });
+
+    // retryLimit: 0 disables pg-boss's built-in retries so the engine fully
+    // owns retry logic. Any failure (including timeout from a dead worker)
+    // immediately routes the job to the dead-letter queue.
+    await this.boss.createQueue(WORKFLOW_RUN_QUEUE_NAME, {
+      retryLimit: 0,
+      deadLetter: STUCK_WORKFLOW_RUN_QUEUE_NAME,
+    });
+
+    // createQueue is a no-op for existing queues, so explicitly update
+    // settings to ensure installations that predate the DLQ pick it up.
+    await this.boss.updateQueue(WORKFLOW_RUN_QUEUE_NAME, {
+      retryLimit: 0,
+      deadLetter: STUCK_WORKFLOW_RUN_QUEUE_NAME,
+    });
 
     const numWorkers: number = +(process.env.WORKFLOW_RUN_WORKERS ?? 3);
 
@@ -174,6 +200,13 @@ export class WorkflowEngine {
           `Worker ${i + 1}/${numWorkers} started for queue ${WORKFLOW_RUN_QUEUE_NAME}`,
         );
       }
+
+      await this.boss.work<WorkflowRunJobParameters>(
+        STUCK_WORKFLOW_RUN_QUEUE_NAME,
+        { pollingIntervalSeconds: 0.5, batchSize: 1 },
+        (job) => this.handleStuckWorkflowRun(job),
+      );
+      this.logger.log(`Worker started for queue ${STUCK_WORKFLOW_RUN_QUEUE_NAME}`);
     }
 
     this._started = true;
@@ -977,6 +1010,81 @@ export class WorkflowEngine {
 
       throw error;
     }
+  }
+
+  /**
+   * Reconciles workflow runs whose worker died mid-execution. pg-boss routes
+   * jobs that time out (or otherwise fail without the handler running to
+   * completion) to the dead-letter queue, with the original job payload
+   * preserved. We use that payload to find the orphaned workflow_runs row
+   * and either retry it with the engine's exponential backoff or mark it
+   * FAILED if retries are exhausted.
+   */
+  private async handleStuckWorkflowRun([job]: Job<WorkflowRunJobParameters>[]) {
+    const { runId, resourceId, workflowId, input } = job?.data ?? {};
+
+    if (!runId) {
+      return;
+    }
+
+    let run: WorkflowRun;
+    try {
+      run = await this.getRun({ runId });
+    } catch (error) {
+      if (error instanceof WorkflowRunNotFoundError) {
+        return;
+      }
+      throw error;
+    }
+
+    // Only RUNNING runs are stuck. Terminal states (completed/failed/cancelled)
+    // and PAUSED runs need no recovery — a failed catch handler will have
+    // already marked the run FAILED, and a paused run isn't waiting on this job.
+    if (run.status !== WorkflowStatus.RUNNING) {
+      return;
+    }
+
+    const scopedResourceId = this.resolveScopedResourceId(resourceId, run);
+
+    if (run.retryCount < run.maxRetries) {
+      await this.updateRun({
+        runId,
+        resourceId: scopedResourceId,
+        data: { retryCount: run.retryCount + 1 },
+      });
+
+      const retryDelay = 2 ** run.retryCount * 1000;
+      const retryJob: WorkflowRunJobParameters = {
+        runId,
+        resourceId: scopedResourceId,
+        workflowId: workflowId ?? run.workflowId,
+        input: input ?? run.input,
+      };
+      await this.boss.send(WORKFLOW_RUN_QUEUE_NAME, retryJob, {
+        startAfter: new Date(Date.now() + retryDelay),
+        expireInSeconds: defaultExpireInSeconds,
+      });
+
+      this.logger.log(
+        `Retrying stuck workflow run (attempt ${run.retryCount + 1}/${run.maxRetries})`,
+        { runId, workflowId: run.workflowId },
+      );
+      return;
+    }
+
+    await this.updateRun({
+      runId,
+      resourceId: scopedResourceId,
+      data: {
+        status: WorkflowStatus.FAILED,
+        error: 'Workflow run worker died or job expired before completion',
+      },
+    });
+
+    this.logger.log('Marked stuck workflow run as failed', {
+      runId,
+      workflowId: run.workflowId,
+    });
   }
 
   private getCachedStepEntry(

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -1,5 +1,4 @@
 import pg from 'pg';
-import type { PgBoss } from 'pg-boss';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { z } from 'zod';
 import { DEFAULT_PGBOSS_SCHEMA, WORKFLOW_RUN_DLQ_QUEUE_NAME } from './constants';
@@ -117,27 +116,6 @@ const retryWorkflow = workflow(
   { retries: 5 },
 );
 
-let cachedStepOneRuns = 0;
-let cachedStepTwoRuns = 0;
-const cachedRetryWorkflow = workflow(
-  'integration-cached-retry',
-  async ({ step }) => {
-    const first = await step.run('charge', async () => {
-      cachedStepOneRuns++;
-      return { charged: true };
-    });
-    const second = await step.run('notify', async () => {
-      cachedStepTwoRuns++;
-      if (cachedStepTwoRuns < 3) {
-        throw new Error(`notify boom #${cachedStepTwoRuns}`);
-      }
-      return { notified: true, prevCharged: first.charged };
-    });
-    return second;
-  },
-  { retries: 5 },
-);
-
 const pauseResumeWorkflow = workflow('integration-pause-resume', async ({ step }) => {
   const before = await step.run('before-pause', async () => {
     return { phase: 'before' };
@@ -183,7 +161,6 @@ describe('WorkflowEngine Integration (real PostgreSQL)', () => {
         inputValidationWorkflow,
         waitForEventWorkflow,
         retryWorkflow,
-        cachedRetryWorkflow,
         pauseResumeWorkflow,
         cancelWorkflow,
       ],
@@ -339,29 +316,6 @@ describe('WorkflowEngine Integration (real PostgreSQL)', () => {
     expect(result.retryCount).toBeGreaterThanOrEqual(2);
   });
 
-  it('should not re-execute completed steps when retries occur', async () => {
-    // End-to-end durability proof: step 'charge' must run exactly once even
-    // though step 'notify' fails twice. On retries, the engine reads the
-    // 'charge' result from the timeline and skips its handler.
-    cachedStepOneRuns = 0;
-    cachedStepTwoRuns = 0;
-
-    const resourceId = `test-cached-retry-${Date.now()}`;
-    const run = await engine.startWorkflow({
-      workflowId: 'integration-cached-retry',
-      resourceId,
-      input: {},
-    });
-
-    const result = await waitForStatus(run.id, resourceId, ['completed', 'failed']);
-
-    expect(result.status).toBe(WorkflowStatus.COMPLETED);
-    expect(cachedStepOneRuns).toBe(1);
-    expect(cachedStepTwoRuns).toBe(3);
-    expect(result.output).toEqual({ notified: true, prevCharged: true });
-    expect(result.retryCount).toBeGreaterThanOrEqual(2);
-  });
-
   it('should pause and resume a workflow manually', async () => {
     const resourceId = `test-pause-${Date.now()}`;
     const run = await engine.startWorkflow({
@@ -460,55 +414,6 @@ describe('WorkflowEngine Integration (real PostgreSQL)', () => {
   });
 
   describe('dead-letter recovery for stuck runs', () => {
-    const insertStuckRun = async ({
-      workflowId,
-      retryCount,
-      maxRetries,
-      status,
-      resourceId,
-    }: {
-      workflowId: string;
-      retryCount: number;
-      maxRetries: number;
-      status: WorkflowStatus;
-      resourceId: string;
-    }) => {
-      const runId = `run_dlq_${Math.random().toString(36).slice(2, 12)}`;
-      const now = new Date();
-      await pool.query(
-        `INSERT INTO workflow_runs (
-          id, resource_id, workflow_id, current_step_id, status, input,
-          max_retries, retry_count, timeline, created_at, updated_at
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
-        [
-          runId,
-          resourceId,
-          workflowId,
-          'step-1',
-          status,
-          JSON.stringify({}),
-          maxRetries,
-          retryCount,
-          '{}',
-          now,
-          now,
-        ],
-      );
-      return runId;
-    };
-
-    const sendToDlq = async (runId: string, resourceId: string, workflowId: string) => {
-      // Reuse the engine's pg-boss instance so we send to the same schema
-      // that the DLQ worker is listening on.
-      const boss = (engine as unknown as { boss: PgBoss }).boss;
-      await boss.send(WORKFLOW_RUN_DLQ_QUEUE_NAME, {
-        runId,
-        resourceId,
-        workflowId,
-        input: {},
-      });
-    };
-
     it('should configure the workflow-run queue with the DLQ + heartbeat options', async () => {
       const { rows } = await pool.query<{
         retry_limit: number;
@@ -527,68 +432,11 @@ describe('WorkflowEngine Integration (real PostgreSQL)', () => {
       expect(rows[0].heartbeat_seconds).toBe(30);
     });
 
-    it('should retry a stuck RUNNING run when retries are available', async () => {
-      const resourceId = `test-dlq-retry-${Date.now()}`;
-      const runId = await insertStuckRun({
-        workflowId: 'integration-sequential',
-        retryCount: 0,
-        maxRetries: 3,
-        status: WorkflowStatus.RUNNING,
-        resourceId,
-      });
-
-      await sendToDlq(runId, resourceId, 'integration-sequential');
-
-      // DLQ worker bumps retryCount and re-enqueues; main worker resumes the
-      // workflow from scratch and completes it.
-      const result = await waitForStatus(runId, resourceId, ['completed'], 15_000);
-      expect(result.status).toBe(WorkflowStatus.COMPLETED);
-      expect(result.retryCount).toBeGreaterThanOrEqual(1);
-    });
-
-    it('should mark a stuck RUNNING run as FAILED when retries are exhausted', async () => {
-      const resourceId = `test-dlq-fail-${Date.now()}`;
-      const runId = await insertStuckRun({
-        workflowId: 'integration-sequential',
-        retryCount: 2,
-        maxRetries: 2,
-        status: WorkflowStatus.RUNNING,
-        resourceId,
-      });
-
-      await sendToDlq(runId, resourceId, 'integration-sequential');
-
-      const result = await waitForStatus(runId, resourceId, ['failed'], 10_000);
-      expect(result.status).toBe(WorkflowStatus.FAILED);
-      expect(result.error).toContain('worker died');
-    });
-
-    it('should not modify runs that are no longer in RUNNING status', async () => {
-      const resourceId = `test-dlq-noop-${Date.now()}`;
-      const runId = await insertStuckRun({
-        workflowId: 'integration-sequential',
-        retryCount: 0,
-        maxRetries: 2,
-        status: WorkflowStatus.COMPLETED,
-        resourceId,
-      });
-
-      await sendToDlq(runId, resourceId, 'integration-sequential');
-
-      // Give the DLQ worker time to process and confirm no state change.
-      await sleep(2000);
-
-      const after = await engine.getRun({ runId, resourceId });
-      expect(after.status).toBe(WorkflowStatus.COMPLETED);
-      expect(after.retryCount).toBe(0);
-    });
-
     it('should route a real failed job to the DLQ via pg-boss when handler re-throws', async () => {
-      // Define a workflow that always fails; with retries=0 the engine catch
-      // marks the run FAILED then re-throws, which makes pg-boss fail the job.
-      // Because retryLimit: 0 + deadLetter is set on the queue, pg-boss copies
-      // the payload to workflow_run_dlq. The DLQ worker sees status=FAILED and
-      // no-ops — verifying the entire pipeline wires up correctly.
+      // retries=0 + retryLimit=0 on the queue means a thrown handler error
+      // causes pg-boss to copy the payload to workflow_run_dlq. The DLQ
+      // worker sees status=FAILED and no-ops — verifying the pipeline wires
+      // up correctly end-to-end on real PostgreSQL.
       const alwaysFails = workflow(
         'integration-dlq-route',
         async ({ step }) => {
@@ -610,8 +458,6 @@ describe('WorkflowEngine Integration (real PostgreSQL)', () => {
       const result = await waitForStatus(run.id, resourceId, ['failed'], 10_000);
       expect(result.status).toBe(WorkflowStatus.FAILED);
 
-      // Confirm pg-boss actually routed the failed job to the DLQ table by
-      // checking that a DLQ job exists with this runId.
       const { rows } = await pool.query<{ count: string }>(
         `SELECT COUNT(*)::text AS count
            FROM ${DEFAULT_PGBOSS_SCHEMA}.job

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -117,6 +117,27 @@ const retryWorkflow = workflow(
   { retries: 5 },
 );
 
+let cachedStepOneRuns = 0;
+let cachedStepTwoRuns = 0;
+const cachedRetryWorkflow = workflow(
+  'integration-cached-retry',
+  async ({ step }) => {
+    const first = await step.run('charge', async () => {
+      cachedStepOneRuns++;
+      return { charged: true };
+    });
+    const second = await step.run('notify', async () => {
+      cachedStepTwoRuns++;
+      if (cachedStepTwoRuns < 3) {
+        throw new Error(`notify boom #${cachedStepTwoRuns}`);
+      }
+      return { notified: true, prevCharged: first.charged };
+    });
+    return second;
+  },
+  { retries: 5 },
+);
+
 const pauseResumeWorkflow = workflow('integration-pause-resume', async ({ step }) => {
   const before = await step.run('before-pause', async () => {
     return { phase: 'before' };
@@ -162,6 +183,7 @@ describe('WorkflowEngine Integration (real PostgreSQL)', () => {
         inputValidationWorkflow,
         waitForEventWorkflow,
         retryWorkflow,
+        cachedRetryWorkflow,
         pauseResumeWorkflow,
         cancelWorkflow,
       ],
@@ -314,6 +336,29 @@ describe('WorkflowEngine Integration (real PostgreSQL)', () => {
 
     expect(result.status).toBe(WorkflowStatus.COMPLETED);
     expect(result.output).toEqual({ attempt: 3 });
+    expect(result.retryCount).toBeGreaterThanOrEqual(2);
+  });
+
+  it('should not re-execute completed steps when retries occur', async () => {
+    // End-to-end durability proof: step 'charge' must run exactly once even
+    // though step 'notify' fails twice. On retries, the engine reads the
+    // 'charge' result from the timeline and skips its handler.
+    cachedStepOneRuns = 0;
+    cachedStepTwoRuns = 0;
+
+    const resourceId = `test-cached-retry-${Date.now()}`;
+    const run = await engine.startWorkflow({
+      workflowId: 'integration-cached-retry',
+      resourceId,
+      input: {},
+    });
+
+    const result = await waitForStatus(run.id, resourceId, ['completed', 'failed']);
+
+    expect(result.status).toBe(WorkflowStatus.COMPLETED);
+    expect(cachedStepOneRuns).toBe(1);
+    expect(cachedStepTwoRuns).toBe(3);
+    expect(result.output).toEqual({ notified: true, prevCharged: true });
     expect(result.retryCount).toBeGreaterThanOrEqual(2);
   });
 

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -1,6 +1,8 @@
 import pg from 'pg';
+import type { PgBoss } from 'pg-boss';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { z } from 'zod';
+import { DEFAULT_PGBOSS_SCHEMA, WORKFLOW_RUN_DLQ_QUEUE_NAME } from './constants';
 import { workflow } from './definition';
 import { WorkflowEngine } from './engine';
 import { WorkflowStatus } from './types';
@@ -410,6 +412,171 @@ describe('WorkflowEngine Integration (real PostgreSQL)', () => {
       expect(item.status).toBe(WorkflowStatus.COMPLETED);
       expect(item.resourceId).toBe(resourceId);
     }
+  });
+
+  describe('dead-letter recovery for stuck runs', () => {
+    const insertStuckRun = async ({
+      workflowId,
+      retryCount,
+      maxRetries,
+      status,
+      resourceId,
+    }: {
+      workflowId: string;
+      retryCount: number;
+      maxRetries: number;
+      status: WorkflowStatus;
+      resourceId: string;
+    }) => {
+      const runId = `run_dlq_${Math.random().toString(36).slice(2, 12)}`;
+      const now = new Date();
+      await pool.query(
+        `INSERT INTO workflow_runs (
+          id, resource_id, workflow_id, current_step_id, status, input,
+          max_retries, retry_count, timeline, created_at, updated_at
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+        [
+          runId,
+          resourceId,
+          workflowId,
+          'step-1',
+          status,
+          JSON.stringify({}),
+          maxRetries,
+          retryCount,
+          '{}',
+          now,
+          now,
+        ],
+      );
+      return runId;
+    };
+
+    const sendToDlq = async (runId: string, resourceId: string, workflowId: string) => {
+      // Reuse the engine's pg-boss instance so we send to the same schema
+      // that the DLQ worker is listening on.
+      const boss = (engine as unknown as { boss: PgBoss }).boss;
+      await boss.send(WORKFLOW_RUN_DLQ_QUEUE_NAME, {
+        runId,
+        resourceId,
+        workflowId,
+        input: {},
+      });
+    };
+
+    it('should configure the workflow-run queue with the DLQ + heartbeat options', async () => {
+      const { rows } = await pool.query<{
+        retry_limit: number;
+        dead_letter: string | null;
+        heartbeat_seconds: number | null;
+      }>(
+        `SELECT retry_limit, dead_letter, heartbeat_seconds
+           FROM ${DEFAULT_PGBOSS_SCHEMA}.queue
+          WHERE name = $1`,
+        ['workflow-run'],
+      );
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0].retry_limit).toBe(0);
+      expect(rows[0].dead_letter).toBe(WORKFLOW_RUN_DLQ_QUEUE_NAME);
+      expect(rows[0].heartbeat_seconds).toBe(30);
+    });
+
+    it('should retry a stuck RUNNING run when retries are available', async () => {
+      const resourceId = `test-dlq-retry-${Date.now()}`;
+      const runId = await insertStuckRun({
+        workflowId: 'integration-sequential',
+        retryCount: 0,
+        maxRetries: 3,
+        status: WorkflowStatus.RUNNING,
+        resourceId,
+      });
+
+      await sendToDlq(runId, resourceId, 'integration-sequential');
+
+      // DLQ worker bumps retryCount and re-enqueues; main worker resumes the
+      // workflow from scratch and completes it.
+      const result = await waitForStatus(runId, resourceId, ['completed'], 15_000);
+      expect(result.status).toBe(WorkflowStatus.COMPLETED);
+      expect(result.retryCount).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should mark a stuck RUNNING run as FAILED when retries are exhausted', async () => {
+      const resourceId = `test-dlq-fail-${Date.now()}`;
+      const runId = await insertStuckRun({
+        workflowId: 'integration-sequential',
+        retryCount: 2,
+        maxRetries: 2,
+        status: WorkflowStatus.RUNNING,
+        resourceId,
+      });
+
+      await sendToDlq(runId, resourceId, 'integration-sequential');
+
+      const result = await waitForStatus(runId, resourceId, ['failed'], 10_000);
+      expect(result.status).toBe(WorkflowStatus.FAILED);
+      expect(result.error).toContain('worker died');
+    });
+
+    it('should not modify runs that are no longer in RUNNING status', async () => {
+      const resourceId = `test-dlq-noop-${Date.now()}`;
+      const runId = await insertStuckRun({
+        workflowId: 'integration-sequential',
+        retryCount: 0,
+        maxRetries: 2,
+        status: WorkflowStatus.COMPLETED,
+        resourceId,
+      });
+
+      await sendToDlq(runId, resourceId, 'integration-sequential');
+
+      // Give the DLQ worker time to process and confirm no state change.
+      await sleep(2000);
+
+      const after = await engine.getRun({ runId, resourceId });
+      expect(after.status).toBe(WorkflowStatus.COMPLETED);
+      expect(after.retryCount).toBe(0);
+    });
+
+    it('should route a real failed job to the DLQ via pg-boss when handler re-throws', async () => {
+      // Define a workflow that always fails; with retries=0 the engine catch
+      // marks the run FAILED then re-throws, which makes pg-boss fail the job.
+      // Because retryLimit: 0 + deadLetter is set on the queue, pg-boss copies
+      // the payload to workflow_run_dlq. The DLQ worker sees status=FAILED and
+      // no-ops — verifying the entire pipeline wires up correctly.
+      const alwaysFails = workflow(
+        'integration-dlq-route',
+        async ({ step }) => {
+          await step.run('boom', async () => {
+            throw new Error('intentional boom');
+          });
+        },
+        { retries: 0 },
+      );
+      await engine.registerWorkflow(alwaysFails);
+
+      const resourceId = `test-dlq-route-${Date.now()}`;
+      const run = await engine.startWorkflow({
+        workflowId: 'integration-dlq-route',
+        resourceId,
+        input: {},
+      });
+
+      const result = await waitForStatus(run.id, resourceId, ['failed'], 10_000);
+      expect(result.status).toBe(WorkflowStatus.FAILED);
+
+      // Confirm pg-boss actually routed the failed job to the DLQ table by
+      // checking that a DLQ job exists with this runId.
+      const { rows } = await pool.query<{ count: string }>(
+        `SELECT COUNT(*)::text AS count
+           FROM ${DEFAULT_PGBOSS_SCHEMA}.job
+          WHERE name = $1 AND data->>'runId' = $2`,
+        [WORKFLOW_RUN_DLQ_QUEUE_NAME, run.id],
+      );
+      expect(Number(rows[0].count)).toBeGreaterThanOrEqual(1);
+
+      await engine.unregisterWorkflow('integration-dlq-route');
+    });
   });
 
   it('should persist step results in timeline', async () => {

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -1,7 +1,8 @@
 import pg from 'pg';
+import type { PgBoss } from 'pg-boss';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { z } from 'zod';
-import { DEFAULT_PGBOSS_SCHEMA, WORKFLOW_RUN_DLQ_QUEUE_NAME } from './constants';
+import { WORKFLOW_RUN_DLQ_QUEUE_NAME, WORKFLOW_RUN_QUEUE_NAME } from './constants';
 import { workflow } from './definition';
 import { WorkflowEngine } from './engine';
 import { WorkflowStatus } from './types';
@@ -415,28 +416,21 @@ describe('WorkflowEngine Integration (real PostgreSQL)', () => {
 
   describe('dead-letter recovery for stuck runs', () => {
     it('should configure the workflow-run queue with the DLQ + heartbeat options', async () => {
-      const { rows } = await pool.query<{
-        retry_limit: number;
-        dead_letter: string | null;
-        heartbeat_seconds: number | null;
-      }>(
-        `SELECT retry_limit, dead_letter, heartbeat_seconds
-           FROM ${DEFAULT_PGBOSS_SCHEMA}.queue
-          WHERE name = $1`,
-        ['workflow-run'],
-      );
+      const boss = (engine as unknown as { boss: PgBoss }).boss;
+      const queue = await boss.getQueue(WORKFLOW_RUN_QUEUE_NAME);
 
-      expect(rows).toHaveLength(1);
-      expect(rows[0].retry_limit).toBe(0);
-      expect(rows[0].dead_letter).toBe(WORKFLOW_RUN_DLQ_QUEUE_NAME);
-      expect(rows[0].heartbeat_seconds).toBe(30);
+      expect(queue).not.toBeNull();
+      expect(queue?.retryLimit).toBe(0);
+      expect(queue?.deadLetter).toBe(WORKFLOW_RUN_DLQ_QUEUE_NAME);
+      expect(queue?.heartbeatSeconds).toBe(30);
     });
 
     it('should route a real failed job to the DLQ via pg-boss when handler re-throws', async () => {
-      // retries=0 + retryLimit=0 on the queue means a thrown handler error
-      // causes pg-boss to copy the payload to workflow_run_dlq. The DLQ
-      // worker sees status=FAILED and no-ops — verifying the pipeline wires
-      // up correctly end-to-end on real PostgreSQL.
+      // retries=0 means a thrown handler error exhausts pg-boss retries
+      // immediately, routing the job to the DLQ. status=FAILED proves
+      // handleWorkflowRunDlq ran (only path that flips RUNNING→FAILED), and
+      // the preserved error message proves the catch block persisted it
+      // before pg-boss routed the failure.
       const alwaysFails = workflow(
         'integration-dlq-route',
         async ({ step }) => {
@@ -457,14 +451,7 @@ describe('WorkflowEngine Integration (real PostgreSQL)', () => {
 
       const result = await waitForStatus(run.id, resourceId, ['failed'], 10_000);
       expect(result.status).toBe(WorkflowStatus.FAILED);
-
-      const { rows } = await pool.query<{ count: string }>(
-        `SELECT COUNT(*)::text AS count
-           FROM ${DEFAULT_PGBOSS_SCHEMA}.job
-          WHERE name = $1 AND data->>'runId' = $2`,
-        [WORKFLOW_RUN_DLQ_QUEUE_NAME, run.id],
-      );
-      expect(Number(rows[0].count)).toBeGreaterThanOrEqual(1);
+      expect(result.error).toBe('intentional boom');
 
       await engine.unregisterWorkflow('integration-dlq-route');
     });


### PR DESCRIPTION
## Summary

Fixes workflow runs getting permanently stuck in `RUNNING` status when their workers die mid-execution. Previously, when a worker process crashed before its `try/catch` block could run, the workflow_runs row stayed `RUNNING` forever and the corresponding pg-boss job sat unrecovered.

The fix delegates retry handling to pg-boss's built-in mechanisms (per-job `retryLimit + retryBackoff`, `deadLetter`, `heartbeatSeconds`) and adds a small DLQ worker that reconciles the `workflow_runs` row once pg-boss has exhausted its retries.

## How it works

**Per-job retries via pg-boss** — every `boss.send` for the workflow-run queue now sets `retryLimit + retryBackoff: true + retryDelay: 1` derived from the workflow's `retries` option. pg-boss handles retry scheduling internally with `retryDelay * 2^retryCount` seconds (with jitter) — equivalent to the previous hand-rolled `2^n * 1000ms` backoff.

**Heartbeats for dead-worker detection** — main queue is configured with `heartbeatSeconds: 30` (configurable via `start({ heartbeatSeconds })` or `WORKFLOW_RUN_HEARTBEAT_SECONDS` env). pg-boss workers auto-touch the heartbeat every `heartbeatSeconds / 2`; if the process dies, missed heartbeats trigger pg-boss's monitor to fail the job in ~30-90s instead of waiting for the full `expireInSeconds` (5 min).

**Single failure path** — whether a handler throws or a worker dies (heartbeat miss / job timeout), pg-boss runs the same `failJobs` logic: if `retry_count < retry_limit`, reschedule with backoff; otherwise route to the DLQ.

**`handleWorkflowRun` catch block** — just persists `error.message` to `workflow_runs.error` and re-throws. pg-boss decides retry-vs-DLQ based on the per-job `retryLimit`.

**`handleWorkflowRunDlq`** — runs on the DLQ queue. Reads the workflow_runs row by `runId`; if it's still `RUNNING`, marks it `FAILED` using `run.error` (preserved by the catch block) or a 'worker died or job expired' fallback when no error was persisted.

**`retryCount` mirroring** — main worker uses `includeMetadata: true`, so `job.retryCount` is mirrored into `workflow_runs.retryCount` on every invocation, keeping the field observable to API consumers.

## Behavioral change to be aware of

Retries are now per-job rather than per-workflow-lifetime: each `boss.send` (initial start, triggerEvent wakeup, waitFor/waitUntil timeout, poll re-fire) gets its own retry budget. In practice this is more useful — a workflow that exhausted retries during phase 1 won't fail to recover when phase 2's wakeup encounters a transient error.

## Configuration

- `heartbeatSeconds` — accepted as a `start()` option, defaults to `WORKFLOW_RUN_HEARTBEAT_SECONDS` env or 30s
- `retries` (workflow option) — passed through to pg-boss as `retryLimit` per-job; default 0

## Test plan

5 unit tests + 2 integration tests cover the retry/DLQ paths:

- [x] retry-then-succeed (single-step)
- [x] step caching durability across retries (multi-step; cached step results survive)
- [x] `boss.send` carries the right retry options; eventual FAILED with `retryCount` mirrored and original error preserved
- [x] DLQ worker marks `RUNNING` runs as `FAILED` with the 'worker died' fallback when no error was persisted
- [x] DLQ worker no-ops on terminal status, missing runId, and unknown runId — and stays alive through bad payloads
- [x] queue config introspection on real PostgreSQL: `retryLimit=0`, `deadLetter='workflow_run_dlq'`, `heartbeatSeconds=30`
- [x] end-to-end pg-boss DLQ routing: a thrown handler → status `FAILED` with preserved error message

https://claude.ai/code/session_01VNNPBdkLYfkX7KuNwJHjy7