### PR TITLE
[feat] Add durable child workflow invocation

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -38,10 +38,10 @@ When `boss` is omitted, pg-boss is created automatically with an isolated schema
 | `startWorkflow(ref, input, options?)` | Start a top-level workflow run using a typed ref (see [WorkflowRef](#workflowref)) |
 | `startWorkflow({ workflowId, resourceId?, input, idempotencyKey?, options? })` | Start a top-level workflow run by ID. `resourceId` optionally ties the run to an external entity (see [Resource ID](core-concepts.md#resource-id)). `idempotencyKey` optionally deduplicates starts (see [Idempotency Key](core-concepts.md#idempotency-key)). |
 | `pauseWorkflow({ runId, resourceId? })` | Pause a running workflow |
-| `resumeWorkflow({ runId, resourceId?, options? })` | Resume a paused workflow. No-ops for `step.invokeWorkflow()` waits. |
+| `resumeWorkflow({ runId, resourceId?, options? })` | Resume a paused workflow. No-ops for `step.invokeChildWorkflow()` waits. |
 | `cancelWorkflow({ runId, resourceId? })` | Cancel a workflow |
 | `triggerEvent({ runId, resourceId?, eventName, data?, options? })` | Send an event to a workflow |
-| `fastForwardWorkflow({ runId, resourceId?, data? })` | Skip the current waiting step and resume execution. No-ops for `step.invokeWorkflow()` waits. |
+| `fastForwardWorkflow({ runId, resourceId?, data? })` | Skip the current waiting step and resume execution. No-ops for `step.invokeChildWorkflow()` waits. |
 | `getRun({ runId, resourceId? })` | Get workflow run details |
 | `checkProgress({ runId, resourceId? })` | Get workflow progress |
 | `getRuns(filters)` | List workflow runs with pagination |
@@ -70,10 +70,10 @@ const client = new WorkflowClient({
 | `startWorkflow(ref, input, options?)` | Start a top-level workflow run using a typed ref |
 | `startWorkflow({ workflowId, input, resourceId?, options? })` | Start a top-level workflow run by ID |
 | `pauseWorkflow({ runId, resourceId? })` | Pause a running workflow |
-| `resumeWorkflow({ runId, resourceId?, options? })` | Resume a paused workflow. No-ops for `step.invokeWorkflow()` waits. |
+| `resumeWorkflow({ runId, resourceId?, options? })` | Resume a paused workflow. No-ops for `step.invokeChildWorkflow()` waits. |
 | `cancelWorkflow({ runId, resourceId? })` | Cancel a workflow |
 | `triggerEvent({ runId, resourceId?, eventName, data?, options? })` | Send an event to a workflow |
-| `fastForwardWorkflow({ runId, resourceId?, data? })` | Skip the current waiting step. No-ops for `step.invokeWorkflow()` waits. |
+| `fastForwardWorkflow({ runId, resourceId?, data? })` | Skip the current waiting step. No-ops for `step.invokeChildWorkflow()` waits. |
 | `getRun({ runId, resourceId? })` | Get workflow run details |
 | `checkProgress({ runId, resourceId? })` | Get workflow progress |
 | `getRuns(filters)` | List workflow runs with pagination |
@@ -102,13 +102,13 @@ const definition = myWorkflow(async ({ step, input }) => {
 })
 ```
 
-Refs can also carry an output type for `step.invokeWorkflow()`:
+Refs can also carry an output type for `step.invokeChildWorkflow()`:
 
 ```typescript
 type ChildOutput = { ok: true }
 const childWorkflow = createWorkflowRef<ChildOutput>('child-workflow')
 
-const output = await step.invokeWorkflow('call-child', childWorkflow, {})
+const output = await step.invokeChildWorkflow('call-child', childWorkflow, {})
 // output is ChildOutput
 ```
 
@@ -148,16 +148,16 @@ The context object passed to workflow handlers:
     sleep: (stepId, duration) => Promise<void>,
     pause: (stepId) => Promise<void>,
     poll: <T>(stepId, conditionFn, { interval?, timeout? }) => Promise<{ timedOut: false; data: T } | { timedOut: true }>,
-    // invokeWorkflow has two overloads:
+    // invokeChildWorkflow has two overloads:
     //   1) by typed `WorkflowRef<TInput, TOutput>` - return type is inferred
-    invokeWorkflow: <TInput, TOutput>(stepId, ref: WorkflowRef<TInput, TOutput>, input, options?) => Promise<TOutput>,
+    invokeChildWorkflow: <TInput, TOutput>(stepId, ref: WorkflowRef<TInput, TOutput>, input, options?) => Promise<TOutput>,
     //   2) by workflow ID - explicit `<TOutput>` generic for the return
-    invokeWorkflow: <TOutput>(stepId, { workflowId, input, resourceId?, idempotencyKey?, options? }) => Promise<TOutput>,
+    invokeChildWorkflow: <TOutput>(stepId, { workflowId, input, resourceId?, idempotencyKey?, options? }) => Promise<TOutput>,
   }
 }
 ```
 
-`startWorkflow()` creates a top-level run and returns immediately. `step.invokeWorkflow()` starts a child run from inside a workflow, pauses the parent, and resolves with the child output when the child reaches a terminal state.
+`startWorkflow()` creates a top-level run and returns immediately. `step.invokeChildWorkflow()` starts a child run from inside a workflow, pauses the parent, and resolves with the child output when the child reaches a terminal state.
 
 `duration` is a string (e.g. `'3 days'`, `'2h'`) or an object (`{ weeks?, days?, hours?, minutes?, seconds? }`). See the `Duration` type and `parseDuration` from the package.
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -35,10 +35,10 @@ When `boss` is omitted, pg-boss is created automatically with an isolated schema
 | `start(asEngine?, options?)` | Start the engine and workers |
 | `stop()` | Stop the engine gracefully |
 | `registerWorkflow(definition)` | Register a workflow definition |
-| `startWorkflow(ref, input, options?)` | Start a workflow using a typed ref (see [WorkflowRef](#workflowref)) |
-| `startWorkflow({ workflowId, resourceId?, input, idempotencyKey?, options? })` | Start a workflow by ID. `resourceId` optionally ties the run to an external entity (see [Resource ID](core-concepts.md#resource-id)). `idempotencyKey` optionally deduplicates starts (see [Idempotency Key](core-concepts.md#idempotency-key)). |
+| `startWorkflow(ref, input, options?)` | Start a top-level workflow run using a typed ref (see [WorkflowRef](#workflowref)) |
+| `startWorkflow({ workflowId, resourceId?, input, idempotencyKey?, options? })` | Start a top-level workflow run by ID. `resourceId` optionally ties the run to an external entity (see [Resource ID](core-concepts.md#resource-id)). `idempotencyKey` optionally deduplicates starts (see [Idempotency Key](core-concepts.md#idempotency-key)). |
 | `pauseWorkflow({ runId, resourceId? })` | Pause a running workflow |
-| `resumeWorkflow({ runId, resourceId?, options? })` | Resume a paused workflow |
+| `resumeWorkflow({ runId, resourceId?, options? })` | Resume a paused workflow. No-ops for `step.invokeWorkflow()` waits. |
 | `cancelWorkflow({ runId, resourceId? })` | Cancel a workflow |
 | `triggerEvent({ runId, resourceId?, eventName, data?, options? })` | Send an event to a workflow |
 | `fastForwardWorkflow({ runId, resourceId?, data? })` | Skip the current waiting step and resume execution. No-ops for `step.invokeWorkflow()` waits. |
@@ -67,10 +67,10 @@ const client = new WorkflowClient({
 |--------|-------------|
 | `start()` | Connect to the database (called automatically on first use) |
 | `stop()` | Close the connection |
-| `startWorkflow(ref, input, options?)` | Start a workflow using a typed ref |
-| `startWorkflow({ workflowId, input, resourceId?, options? })` | Start a workflow by ID |
+| `startWorkflow(ref, input, options?)` | Start a top-level workflow run using a typed ref |
+| `startWorkflow({ workflowId, input, resourceId?, options? })` | Start a top-level workflow run by ID |
 | `pauseWorkflow({ runId, resourceId? })` | Pause a running workflow |
-| `resumeWorkflow({ runId, resourceId?, options? })` | Resume a paused workflow |
+| `resumeWorkflow({ runId, resourceId?, options? })` | Resume a paused workflow. No-ops for `step.invokeWorkflow()` waits. |
 | `cancelWorkflow({ runId, resourceId? })` | Cancel a workflow |
 | `triggerEvent({ runId, resourceId?, eventName, data?, options? })` | Send an event to a workflow |
 | `fastForwardWorkflow({ runId, resourceId?, data? })` | Skip the current waiting step. No-ops for `step.invokeWorkflow()` waits. |
@@ -100,6 +100,16 @@ const definition = myWorkflow(async ({ step, input }) => {
     /* ... */
   })
 })
+```
+
+Refs can also carry an output type for `step.invokeWorkflow()`:
+
+```typescript
+type ChildOutput = { ok: true }
+const childWorkflow = createWorkflowRef<ChildOutput>('child-workflow')
+
+const output = await step.invokeWorkflow('call-child', childWorkflow, {})
+// output is ChildOutput
 ```
 
 ## workflow()
@@ -146,6 +156,8 @@ The context object passed to workflow handlers:
   }
 }
 ```
+
+`startWorkflow()` creates a top-level run and returns immediately. `step.invokeWorkflow()` starts a child run from inside a workflow, pauses the parent, and resolves with the child output when the child reaches a terminal state.
 
 `duration` is a string (e.g. `'3 days'`, `'2h'`) or an object (`{ weeks?, days?, hours?, minutes?, seconds? }`). See the `Duration` type and `parseDuration` from the package.
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -41,7 +41,7 @@ When `boss` is omitted, pg-boss is created automatically with an isolated schema
 | `resumeWorkflow({ runId, resourceId?, options? })` | Resume a paused workflow |
 | `cancelWorkflow({ runId, resourceId? })` | Cancel a workflow |
 | `triggerEvent({ runId, resourceId?, eventName, data?, options? })` | Send an event to a workflow |
-| `fastForwardWorkflow({ runId, resourceId?, data? })` | Skip the current waiting step and resume execution |
+| `fastForwardWorkflow({ runId, resourceId?, data? })` | Skip the current waiting step and resume execution. No-ops for `step.invokeWorkflow()` waits. |
 | `getRun({ runId, resourceId? })` | Get workflow run details |
 | `checkProgress({ runId, resourceId? })` | Get workflow progress |
 | `getRuns(filters)` | List workflow runs with pagination |
@@ -73,7 +73,7 @@ const client = new WorkflowClient({
 | `resumeWorkflow({ runId, resourceId?, options? })` | Resume a paused workflow |
 | `cancelWorkflow({ runId, resourceId? })` | Cancel a workflow |
 | `triggerEvent({ runId, resourceId?, eventName, data?, options? })` | Send an event to a workflow |
-| `fastForwardWorkflow({ runId, resourceId?, data? })` | Skip the current waiting step |
+| `fastForwardWorkflow({ runId, resourceId?, data? })` | Skip the current waiting step. No-ops for `step.invokeWorkflow()` waits. |
 | `getRun({ runId, resourceId? })` | Get workflow run details |
 | `checkProgress({ runId, resourceId? })` | Get workflow progress |
 | `getRuns(filters)` | List workflow runs with pagination |
@@ -138,6 +138,11 @@ The context object passed to workflow handlers:
     sleep: (stepId, duration) => Promise<void>,
     pause: (stepId) => Promise<void>,
     poll: <T>(stepId, conditionFn, { interval?, timeout? }) => Promise<{ timedOut: false; data: T } | { timedOut: true }>,
+    // invokeWorkflow has two overloads:
+    //   1) by typed `WorkflowRef<TInput, TOutput>` - return type is inferred
+    invokeWorkflow: <TInput, TOutput>(stepId, ref: WorkflowRef<TInput, TOutput>, input, options?) => Promise<TOutput>,
+    //   2) by workflow ID - explicit `<TOutput>` generic for the return
+    invokeWorkflow: <TOutput>(stepId, { workflowId, input, resourceId?, idempotencyKey?, options? }) => Promise<TOutput>,
   }
 }
 ```

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -98,7 +98,7 @@ Start a child workflow from inside a parent workflow and wait for it to complete
 
 ```typescript
 const parent = workflow('parent-workflow', async ({ step, input }) => {
-  const childOutput = await step.invokeWorkflow('run-child', childWorkflowRef, {
+  const childOutput = await step.invokeChildWorkflow('run-child', childWorkflowRef, {
     userId: input.userId,
   });
 
@@ -106,12 +106,12 @@ const parent = workflow('parent-workflow', async ({ step, input }) => {
 });
 ```
 
-`step.invokeWorkflow` is durable. Unlike `startWorkflow()`, which creates a top-level run and returns immediately, `invokeWorkflow()` is a child call: the child run is started once for the parent step, the parent pauses while the child runs, and the child output is cached on the parent timeline when it completes. If the child fails or is cancelled, the parent step throws and follows the parent workflow's normal retry/failure behavior.
+`step.invokeChildWorkflow` is durable. Unlike `startWorkflow()`, which creates a top-level run and returns immediately, `invokeChildWorkflow()` is a child call: the child run is started once for the parent step, the parent pauses while the child runs, and the child output is cached on the parent timeline when it completes. If the child fails or is cancelled, the parent step throws and follows the parent workflow's normal retry/failure behavior.
 
 You can also invoke by workflow ID:
 
 ```typescript
-const result = await step.invokeWorkflow<{ ok: true }>('run-child', {
+const result = await step.invokeChildWorkflow<{ ok: true }>('run-child', {
   workflowId: 'child-workflow',
   input: { userId: input.userId },
 });
@@ -119,8 +119,8 @@ const result = await step.invokeWorkflow<{ ok: true }>('run-child', {
 
 ### Behavioral notes
 
-- **Cancellation does not propagate to children.** Cancelling a parent (via `cancelWorkflow` or a parent timeout) does not cancel any in-flight child workflows started via `invokeWorkflow`. Children run to their own terminal state; the wakeup event the child would normally send to the parent is dropped because the parent is no longer in `paused`. The same applies if the parent reaches any other terminal state (failed or completed) while a child is in flight.
-- **Manual resume and fast-forward do not skip child waits.** `resumeWorkflow()` and `fastForwardWorkflow()` are no-ops while a parent is paused on `step.invokeWorkflow()`. The parent only moves forward when the child completes, fails, or is cancelled.
+- **Cancellation does not propagate to children.** Cancelling a parent (via `cancelWorkflow` or a parent timeout) does not cancel any in-flight child workflows started via `invokeChildWorkflow`. Children run to their own terminal state; the wakeup event the child would normally send to the parent is dropped because the parent is no longer in `paused`. The same applies if the parent reaches any other terminal state (failed or completed) while a child is in flight.
+- **Manual resume and fast-forward do not skip child waits.** `resumeWorkflow()` and `fastForwardWorkflow()` are no-ops while a parent is paused on `step.invokeChildWorkflow()`. The parent only moves forward when the child completes, fails, or is cancelled.
 
 ## Resource ID
 
@@ -183,11 +183,11 @@ await engine.resumeWorkflow({
 })
 ```
 
-`resumeWorkflow()` does not force a parent past a `step.invokeWorkflow()` wait. Child workflow waits resume only when the child completes, fails, or is cancelled.
+`resumeWorkflow()` does not force a parent past a `step.invokeChildWorkflow()` wait. Child workflow waits resume only when the child completes, fails, or is cancelled.
 
 ## Fast-Forward
 
-Skip the current waiting step and immediately resume execution. `fastForwardWorkflow` inspects the paused step and dispatches the right internal action — `triggerEvent` for `waitFor`, timeout triggers for `delay`/`waitUntil`, resume for `pause`, and direct output writes for `poll`. If the workflow is not paused or is paused on `step.invokeWorkflow()`, it's a no-op.
+Skip the current waiting step and immediately resume execution. `fastForwardWorkflow` inspects the paused step and dispatches the right internal action — `triggerEvent` for `waitFor`, timeout triggers for `delay`/`waitUntil`, resume for `pause`, and direct output writes for `poll`. If the workflow is not paused or is paused on `step.invokeChildWorkflow()`, it's a no-op.
 
 Useful for testing, debugging, or manually advancing workflows past long waits.
 
@@ -219,7 +219,7 @@ await engine.fastForwardWorkflow({
 | `step.delay()` / `step.waitUntil()` | Triggers the timeout event to skip the wait                                  |
 | `step.poll()`                       | Writes `data` as the poll result and triggers resolution                     |
 | `step.pause()`                      | Delegates to `resumeWorkflow()`                                              |
-| `step.invokeWorkflow()`             | No-op; child completion, failure, or cancellation controls the parent result |
+| `step.invokeChildWorkflow()`        | No-op; child completion, failure, or cancellation controls the parent result |
 
 ## Input Validation
 

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -106,7 +106,7 @@ const parent = workflow('parent-workflow', async ({ step, input }) => {
 });
 ```
 
-`step.invokeWorkflow` is durable. The child run is started once for the parent step, the parent pauses while the child runs, and the child output is cached on the parent timeline when it completes. If the child fails or is cancelled, the parent step throws and follows the parent workflow's normal retry/failure behavior.
+`step.invokeWorkflow` is durable. Unlike `startWorkflow()`, which creates a top-level run and returns immediately, `invokeWorkflow()` is a child call: the child run is started once for the parent step, the parent pauses while the child runs, and the child output is cached on the parent timeline when it completes. If the child fails or is cancelled, the parent step throws and follows the parent workflow's normal retry/failure behavior.
 
 You can also invoke by workflow ID:
 
@@ -119,7 +119,8 @@ const result = await step.invokeWorkflow<{ ok: true }>('run-child', {
 
 ### Behavioral notes
 
-- **Cancellation does not propagate to children.** Cancelling a parent (via `cancelWorkflow` or a parent timeout) leaves any in-flight child runs running. They run to their terminal state; the wakeup event the child would normally send to the parent is dropped because the parent is no longer in `paused`.
+- **Cancellation does not propagate to children.** Cancelling a parent (via `cancelWorkflow` or a parent timeout) does not cancel any in-flight child workflows started via `invokeWorkflow`. Children run to their own terminal state; the wakeup event the child would normally send to the parent is dropped because the parent is no longer in `paused`. The same applies if the parent reaches any other terminal state (failed or completed) while a child is in flight.
+- **Manual resume and fast-forward do not skip child waits.** `resumeWorkflow()` and `fastForwardWorkflow()` are no-ops while a parent is paused on `step.invokeWorkflow()`. The parent only moves forward when the child completes, fails, or is cancelled.
 
 ## Resource ID
 
@@ -182,9 +183,11 @@ await engine.resumeWorkflow({
 })
 ```
 
+`resumeWorkflow()` does not force a parent past a `step.invokeWorkflow()` wait. Child workflow waits resume only when the child completes, fails, or is cancelled.
+
 ## Fast-Forward
 
-Skip the current waiting step and immediately resume execution. `fastForwardWorkflow` inspects the paused step and dispatches the right internal action — `triggerEvent` for `waitFor`, timeout triggers for `delay`/`waitUntil`, resume for `pause`, and direct output writes for `poll`. If the workflow is not paused, it's a no-op.
+Skip the current waiting step and immediately resume execution. `fastForwardWorkflow` inspects the paused step and dispatches the right internal action — `triggerEvent` for `waitFor`, timeout triggers for `delay`/`waitUntil`, resume for `pause`, and direct output writes for `poll`. If the workflow is not paused or is paused on `step.invokeWorkflow()`, it's a no-op.
 
 Useful for testing, debugging, or manually advancing workflows past long waits.
 

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -6,16 +6,16 @@ A workflow is a durable function that breaks complex operations into discrete, r
 
 ```typescript
 const myWorkflow = workflow(
-  "workflow-id",
+  'workflow-id',
   async ({ step, input }) => {
     // Your workflow logic here
   },
   {
     inputSchema: mySchema, // any Standard Schema-compliant schema
-    timeout: 60000, // milliseconds
+    timeout: 60000,        // milliseconds
     retries: 3,
   },
-);
+)
 ```
 
 ## Steps
@@ -23,10 +23,10 @@ const myWorkflow = workflow(
 Steps are the building blocks of durable workflows. Each step is executed **exactly once**, even if the workflow is retried:
 
 ```typescript
-await step.run("step-id", async () => {
+await step.run('step-id', async () => {
   // This will only execute once — the result is persisted in Postgres
-  return { result: "data" };
-});
+  return { result: 'data' }
+})
 ```
 
 **Step IDs must be unique within a workflow.** When using loops, use dynamic IDs: `step.run(\`process-${item.id}\`, ...)`.
@@ -36,10 +36,10 @@ await step.run("step-id", async () => {
 Wait for external events to pause and resume workflows without consuming resources:
 
 ```typescript
-const eventData = await step.waitFor("wait-step", {
-  eventName: "payment-completed",
+const eventData = await step.waitFor('wait-step', {
+  eventName: 'payment-completed',
   timeout: 5 * 60 * 1000, // 5 minutes
-});
+})
 ```
 
 Send events from outside the workflow:
@@ -47,9 +47,9 @@ Send events from outside the workflow:
 ```typescript
 await engine.triggerEvent({
   runId: run.id,
-  eventName: "payment-completed",
+  eventName: 'payment-completed',
   data: { amount: 99 },
-});
+})
 ```
 
 ## Scheduled & Delay Steps
@@ -58,15 +58,15 @@ Wait until a specific time, or delay for a duration (sugar over `waitUntil`). If
 
 ```typescript
 // Wait until a specific date (Date, ISO string, or { date })
-await step.waitUntil("scheduled-step", new Date("2025-06-01"));
-await step.waitUntil("scheduled-step", "2025-06-01T12:00:00.000Z");
-await step.waitUntil("scheduled-step", { date: new Date("2025-06-01") });
+await step.waitUntil('scheduled-step', new Date('2025-06-01'))
+await step.waitUntil('scheduled-step', '2025-06-01T12:00:00.000Z')
+await step.waitUntil('scheduled-step', { date: new Date('2025-06-01') })
 
 // Delay for a duration (string or object). sleep is an alias of delay.
-await step.delay("cool-off", "3 days");
-await step.delay("cool-off", { days: 3 });
-await step.delay("ramp-up", "2 days 12 hours");
-await step.sleep("backoff", "1 hour");
+await step.delay('cool-off', '3 days')
+await step.delay('cool-off', { days: 3 })
+await step.delay('ramp-up', '2 days 12 hours')
+await step.sleep('backoff', '1 hour')
 ```
 
 ## Polling Steps
@@ -75,19 +75,19 @@ Repeatedly check a condition until it returns a truthy value or a timeout expire
 
 ```typescript
 const result = await step.poll(
-  "wait-for-payment",
+  'wait-for-payment',
   async () => {
-    const payment = await getPaymentStatus(input.paymentId);
-    return payment.completed ? payment : false;
+    const payment = await getPaymentStatus(input.paymentId)
+    return payment.completed ? payment : false
   },
-  { interval: "1 minute", timeout: "24 hours" },
-);
+  { interval: '1 minute', timeout: '24 hours' },
+)
 
 if (result.timedOut) {
-  return { status: "expired" };
+  return { status: 'expired' }
 }
 
-return { status: "paid", payment: result.data };
+return { status: 'paid', payment: result.data }
 ```
 
 `conditionFn` returns `false` to keep polling, or a truthy value to resolve the step. The minimum interval is 30s (default). If `timeout` is omitted the step polls indefinitely.
@@ -97,8 +97,8 @@ return { status: "paid", payment: result.data };
 Start a child workflow from inside a parent workflow and wait for it to complete without keeping a worker busy:
 
 ```typescript
-const parent = workflow("parent-workflow", async ({ step, input }) => {
-  const childOutput = await step.invokeWorkflow("run-child", childWorkflowRef, {
+const parent = workflow('parent-workflow', async ({ step, input }) => {
+  const childOutput = await step.invokeWorkflow('run-child', childWorkflowRef, {
     userId: input.userId,
   });
 
@@ -111,8 +111,8 @@ const parent = workflow("parent-workflow", async ({ step, input }) => {
 You can also invoke by workflow ID:
 
 ```typescript
-const result = await step.invokeWorkflow<{ ok: true }>("run-child", {
-  workflowId: "child-workflow",
+const result = await step.invokeWorkflow<{ ok: true }>('run-child', {
+  workflowId: 'child-workflow',
   input: { userId: input.userId },
 });
 ```
@@ -133,15 +133,15 @@ The optional `resourceId` associates a workflow run with an external entity in y
 ```typescript
 // Start a workflow scoped to a specific user
 const run = await engine.startWorkflow({
-  workflowId: "send-welcome-email",
-  resourceId: "user-123", // ties this run to user-123
-  input: { email: "user@example.com" },
-});
+  workflowId: 'send-welcome-email',
+  resourceId: 'user-123', // ties this run to user-123
+  input: { email: 'user@example.com' },
+})
 
 // Later, list all workflow runs for that user
 const { items } = await engine.getRuns({
-  resourceId: "user-123",
-});
+  resourceId: 'user-123',
+})
 ```
 
 ## Idempotency Key
@@ -152,17 +152,17 @@ Keys are **globally unique** in the database (up to 256 characters), not scoped 
 
 ```typescript
 const run = await engine.startWorkflow({
-  workflowId: "send-welcome-email",
-  input: { email: "user@example.com" },
-  idempotencyKey: "send-welcome-email:checkout-session_cs_abc123",
-});
+  workflowId: 'send-welcome-email',
+  input: { email: 'user@example.com' },
+  idempotencyKey: 'send-welcome-email:checkout-session_cs_abc123',
+})
 
 // Idempotent: returns the same run and run.id as above
 const again = await engine.startWorkflow({
-  workflowId: "send-welcome-email",
-  input: { email: "other@example.com" }, // ignored for deduplication
-  idempotencyKey: "send-welcome-email:checkout-session_cs_abc123",
-});
+  workflowId: 'send-welcome-email',
+  input: { email: 'other@example.com' }, // ignored for deduplication
+  idempotencyKey: 'send-welcome-email:checkout-session_cs_abc123',
+})
 ```
 
 The returned `WorkflowRun` includes `idempotencyKey` (or `null` if omitted).
@@ -173,13 +173,13 @@ Manually pause a workflow and resume it later:
 
 ```typescript
 // Pause inside a workflow
-await step.pause("pause-step");
+await step.pause('pause-step')
 
 // Resume from outside the workflow
 await engine.resumeWorkflow({
   runId: run.id,
-  resourceId: "resource-123",
-});
+  resourceId: 'resource-123',
+})
 ```
 
 ## Fast-Forward
@@ -192,22 +192,22 @@ Useful for testing, debugging, or manually advancing workflows past long waits.
 // Fast-forward a waitFor step, providing mock event data
 await engine.fastForwardWorkflow({
   runId: run.id,
-  resourceId: "user-123",
-  data: { approved: true, reviewer: "admin" },
-});
+  resourceId: 'user-123',
+  data: { approved: true, reviewer: 'admin' },
+})
 
 // Fast-forward a delay/waitUntil step (no data needed)
 await engine.fastForwardWorkflow({
   runId: run.id,
-  resourceId: "user-123",
-});
+  resourceId: 'user-123',
+})
 
 // Fast-forward a poll step with mock result data
 await engine.fastForwardWorkflow({
   runId: run.id,
-  resourceId: "user-123",
-  data: { paymentId: "pay_123", status: "completed" },
-});
+  resourceId: 'user-123',
+  data: { paymentId: 'pay_123', status: 'completed' },
+})
 ```
 
 | Paused step type                    | Behavior                                                                     |
@@ -225,16 +225,16 @@ pg-workflows supports any [Standard Schema](https://github.com/standard-schema/s
 ### With Zod
 
 ```typescript
-import { workflow } from "pg-workflows";
-import { z } from "zod";
+import { workflow } from 'pg-workflows'
+import { z } from 'zod'
 
 const myWorkflow = workflow(
-  "user-onboarding",
+  'user-onboarding',
   async ({ step, input }) => {
     // input is typed as { email: string; name: string }
-    await step.run("send-welcome", async () => {
-      return await sendEmail(input.email, `Welcome, ${input.name}!`);
-    });
+    await step.run('send-welcome', async () => {
+      return await sendEmail(input.email, `Welcome, ${input.name}!`)
+    })
   },
   {
     inputSchema: z.object({
@@ -242,22 +242,22 @@ const myWorkflow = workflow(
       name: z.string(),
     }),
   },
-);
+)
 ```
 
 ### With Valibot
 
 ```typescript
-import { workflow } from "pg-workflows";
-import * as v from "valibot";
+import { workflow } from 'pg-workflows'
+import * as v from 'valibot'
 
 const myWorkflow = workflow(
-  "user-onboarding",
+  'user-onboarding',
   async ({ step, input }) => {
     // input is typed as { email: string; name: string }
-    await step.run("send-welcome", async () => {
-      return await sendEmail(input.email, `Welcome, ${input.name}!`);
-    });
+    await step.run('send-welcome', async () => {
+      return await sendEmail(input.email, `Welcome, ${input.name}!`)
+    })
   },
   {
     inputSchema: v.object({
@@ -265,7 +265,7 @@ const myWorkflow = workflow(
       name: v.string(),
     }),
   },
-);
+)
 ```
 
 ### Without a Schema
@@ -273,34 +273,37 @@ const myWorkflow = workflow(
 When no `inputSchema` is provided, input is not validated and `input` is typed as `unknown`. The engine has no guarantee about the shape of the data — it passes through whatever was provided to `startWorkflow()`. You are responsible for narrowing the type yourself:
 
 ```typescript
-import { workflow } from "pg-workflows";
+import { workflow } from 'pg-workflows'
 
-const myWorkflow = workflow("process-order", async ({ step, input }) => {
-  // Option 1: Type assertion - you trust the caller
-  const { orderId, amount } = input as { orderId: string; amount: number };
+const myWorkflow = workflow(
+  'process-order',
+  async ({ step, input }) => {
+    // Option 1: Type assertion - you trust the caller
+    const { orderId, amount } = input as { orderId: string; amount: number }
 
-  await step.run("charge", async () => {
-    return await chargeOrder(orderId, amount);
-  });
-});
+    await step.run('charge', async () => {
+      return await chargeOrder(orderId, amount)
+    })
+  },
+)
 
 const myDefensiveWorkflow = workflow(
-  "process-order-safe",
+  'process-order-safe',
   async ({ step, input }) => {
     // Option 2: Runtime checks - you verify before using
-    if (typeof input !== "object" || input === null) {
-      throw new Error("Expected input to be an object");
+    if (typeof input !== 'object' || input === null) {
+      throw new Error('Expected input to be an object')
     }
-    const { orderId, amount } = input as Record<string, unknown>;
-    if (typeof orderId !== "string" || typeof amount !== "number") {
-      throw new Error("Invalid input shape");
+    const { orderId, amount } = input as Record<string, unknown>
+    if (typeof orderId !== 'string' || typeof amount !== 'number') {
+      throw new Error('Invalid input shape')
     }
 
-    await step.run("charge", async () => {
-      return await chargeOrder(orderId, amount);
-    });
+    await step.run('charge', async () => {
+      return await chargeOrder(orderId, amount)
+    })
   },
-);
+)
 ```
 
 Using an `inputSchema` is recommended — it validates input at the engine boundary before your handler runs, and gives you full type inference with no manual work.

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -6,16 +6,16 @@ A workflow is a durable function that breaks complex operations into discrete, r
 
 ```typescript
 const myWorkflow = workflow(
-  'workflow-id',
+  "workflow-id",
   async ({ step, input }) => {
     // Your workflow logic here
   },
   {
     inputSchema: mySchema, // any Standard Schema-compliant schema
-    timeout: 60000,        // milliseconds
+    timeout: 60000, // milliseconds
     retries: 3,
   },
-)
+);
 ```
 
 ## Steps
@@ -23,10 +23,10 @@ const myWorkflow = workflow(
 Steps are the building blocks of durable workflows. Each step is executed **exactly once**, even if the workflow is retried:
 
 ```typescript
-await step.run('step-id', async () => {
+await step.run("step-id", async () => {
   // This will only execute once — the result is persisted in Postgres
-  return { result: 'data' }
-})
+  return { result: "data" };
+});
 ```
 
 **Step IDs must be unique within a workflow.** When using loops, use dynamic IDs: `step.run(\`process-${item.id}\`, ...)`.
@@ -36,10 +36,10 @@ await step.run('step-id', async () => {
 Wait for external events to pause and resume workflows without consuming resources:
 
 ```typescript
-const eventData = await step.waitFor('wait-step', {
-  eventName: 'payment-completed',
+const eventData = await step.waitFor("wait-step", {
+  eventName: "payment-completed",
   timeout: 5 * 60 * 1000, // 5 minutes
-})
+});
 ```
 
 Send events from outside the workflow:
@@ -47,9 +47,9 @@ Send events from outside the workflow:
 ```typescript
 await engine.triggerEvent({
   runId: run.id,
-  eventName: 'payment-completed',
+  eventName: "payment-completed",
   data: { amount: 99 },
-})
+});
 ```
 
 ## Scheduled & Delay Steps
@@ -58,15 +58,15 @@ Wait until a specific time, or delay for a duration (sugar over `waitUntil`). If
 
 ```typescript
 // Wait until a specific date (Date, ISO string, or { date })
-await step.waitUntil('scheduled-step', new Date('2025-06-01'))
-await step.waitUntil('scheduled-step', '2025-06-01T12:00:00.000Z')
-await step.waitUntil('scheduled-step', { date: new Date('2025-06-01') })
+await step.waitUntil("scheduled-step", new Date("2025-06-01"));
+await step.waitUntil("scheduled-step", "2025-06-01T12:00:00.000Z");
+await step.waitUntil("scheduled-step", { date: new Date("2025-06-01") });
 
 // Delay for a duration (string or object). sleep is an alias of delay.
-await step.delay('cool-off', '3 days')
-await step.delay('cool-off', { days: 3 })
-await step.delay('ramp-up', '2 days 12 hours')
-await step.sleep('backoff', '1 hour')
+await step.delay("cool-off", "3 days");
+await step.delay("cool-off", { days: 3 });
+await step.delay("ramp-up", "2 days 12 hours");
+await step.sleep("backoff", "1 hour");
 ```
 
 ## Polling Steps
@@ -75,22 +75,51 @@ Repeatedly check a condition until it returns a truthy value or a timeout expire
 
 ```typescript
 const result = await step.poll(
-  'wait-for-payment',
+  "wait-for-payment",
   async () => {
-    const payment = await getPaymentStatus(input.paymentId)
-    return payment.completed ? payment : false
+    const payment = await getPaymentStatus(input.paymentId);
+    return payment.completed ? payment : false;
   },
-  { interval: '1 minute', timeout: '24 hours' },
-)
+  { interval: "1 minute", timeout: "24 hours" },
+);
 
 if (result.timedOut) {
-  return { status: 'expired' }
+  return { status: "expired" };
 }
 
-return { status: 'paid', payment: result.data }
+return { status: "paid", payment: result.data };
 ```
 
 `conditionFn` returns `false` to keep polling, or a truthy value to resolve the step. The minimum interval is 30s (default). If `timeout` is omitted the step polls indefinitely.
+
+## Child Workflows
+
+Start a child workflow from inside a parent workflow and wait for it to complete without keeping a worker busy:
+
+```typescript
+const parent = workflow("parent-workflow", async ({ step, input }) => {
+  const childOutput = await step.invokeWorkflow("run-child", childWorkflowRef, {
+    userId: input.userId,
+  });
+
+  return { childOutput };
+});
+```
+
+`step.invokeWorkflow` is durable. The child run is started once for the parent step, the parent pauses while the child runs, and the child output is cached on the parent timeline when it completes. If the child fails or is cancelled, the parent step throws and follows the parent workflow's normal retry/failure behavior.
+
+You can also invoke by workflow ID:
+
+```typescript
+const result = await step.invokeWorkflow<{ ok: true }>("run-child", {
+  workflowId: "child-workflow",
+  input: { userId: input.userId },
+});
+```
+
+### Behavioral notes
+
+- **Cancellation does not propagate to children.** Cancelling a parent (via `cancelWorkflow` or a parent timeout) leaves any in-flight child runs running. They run to their terminal state; the wakeup event the child would normally send to the parent is dropped because the parent is no longer in `paused`.
 
 ## Resource ID
 
@@ -104,15 +133,15 @@ The optional `resourceId` associates a workflow run with an external entity in y
 ```typescript
 // Start a workflow scoped to a specific user
 const run = await engine.startWorkflow({
-  workflowId: 'send-welcome-email',
-  resourceId: 'user-123', // ties this run to user-123
-  input: { email: 'user@example.com' },
-})
+  workflowId: "send-welcome-email",
+  resourceId: "user-123", // ties this run to user-123
+  input: { email: "user@example.com" },
+});
 
 // Later, list all workflow runs for that user
 const { items } = await engine.getRuns({
-  resourceId: 'user-123',
-})
+  resourceId: "user-123",
+});
 ```
 
 ## Idempotency Key
@@ -123,17 +152,17 @@ Keys are **globally unique** in the database (up to 256 characters), not scoped 
 
 ```typescript
 const run = await engine.startWorkflow({
-  workflowId: 'send-welcome-email',
-  input: { email: 'user@example.com' },
-  idempotencyKey: 'send-welcome-email:checkout-session_cs_abc123',
-})
+  workflowId: "send-welcome-email",
+  input: { email: "user@example.com" },
+  idempotencyKey: "send-welcome-email:checkout-session_cs_abc123",
+});
 
 // Idempotent: returns the same run and run.id as above
 const again = await engine.startWorkflow({
-  workflowId: 'send-welcome-email',
-  input: { email: 'other@example.com' }, // ignored for deduplication
-  idempotencyKey: 'send-welcome-email:checkout-session_cs_abc123',
-})
+  workflowId: "send-welcome-email",
+  input: { email: "other@example.com" }, // ignored for deduplication
+  idempotencyKey: "send-welcome-email:checkout-session_cs_abc123",
+});
 ```
 
 The returned `WorkflowRun` includes `idempotencyKey` (or `null` if omitted).
@@ -144,13 +173,13 @@ Manually pause a workflow and resume it later:
 
 ```typescript
 // Pause inside a workflow
-await step.pause('pause-step')
+await step.pause("pause-step");
 
 // Resume from outside the workflow
 await engine.resumeWorkflow({
   runId: run.id,
-  resourceId: 'resource-123',
-})
+  resourceId: "resource-123",
+});
 ```
 
 ## Fast-Forward
@@ -163,30 +192,31 @@ Useful for testing, debugging, or manually advancing workflows past long waits.
 // Fast-forward a waitFor step, providing mock event data
 await engine.fastForwardWorkflow({
   runId: run.id,
-  resourceId: 'user-123',
-  data: { approved: true, reviewer: 'admin' },
-})
+  resourceId: "user-123",
+  data: { approved: true, reviewer: "admin" },
+});
 
 // Fast-forward a delay/waitUntil step (no data needed)
 await engine.fastForwardWorkflow({
   runId: run.id,
-  resourceId: 'user-123',
-})
+  resourceId: "user-123",
+});
 
 // Fast-forward a poll step with mock result data
 await engine.fastForwardWorkflow({
   runId: run.id,
-  resourceId: 'user-123',
-  data: { paymentId: 'pay_123', status: 'completed' },
-})
+  resourceId: "user-123",
+  data: { paymentId: "pay_123", status: "completed" },
+});
 ```
 
-| Paused step type | Behavior |
-|------------------|----------|
-| `step.waitFor()` | Triggers the event with `data` (defaults to `{}`) |
-| `step.delay()` / `step.waitUntil()` | Triggers the timeout event to skip the wait |
-| `step.poll()` | Writes `data` as the poll result and triggers resolution |
-| `step.pause()` | Delegates to `resumeWorkflow()` |
+| Paused step type                    | Behavior                                                                     |
+| ----------------------------------- | ---------------------------------------------------------------------------- |
+| `step.waitFor()`                    | Triggers the event with `data` (defaults to `{}`)                            |
+| `step.delay()` / `step.waitUntil()` | Triggers the timeout event to skip the wait                                  |
+| `step.poll()`                       | Writes `data` as the poll result and triggers resolution                     |
+| `step.pause()`                      | Delegates to `resumeWorkflow()`                                              |
+| `step.invokeWorkflow()`             | No-op; child completion, failure, or cancellation controls the parent result |
 
 ## Input Validation
 
@@ -195,16 +225,16 @@ pg-workflows supports any [Standard Schema](https://github.com/standard-schema/s
 ### With Zod
 
 ```typescript
-import { workflow } from 'pg-workflows'
-import { z } from 'zod'
+import { workflow } from "pg-workflows";
+import { z } from "zod";
 
 const myWorkflow = workflow(
-  'user-onboarding',
+  "user-onboarding",
   async ({ step, input }) => {
     // input is typed as { email: string; name: string }
-    await step.run('send-welcome', async () => {
-      return await sendEmail(input.email, `Welcome, ${input.name}!`)
-    })
+    await step.run("send-welcome", async () => {
+      return await sendEmail(input.email, `Welcome, ${input.name}!`);
+    });
   },
   {
     inputSchema: z.object({
@@ -212,22 +242,22 @@ const myWorkflow = workflow(
       name: z.string(),
     }),
   },
-)
+);
 ```
 
 ### With Valibot
 
 ```typescript
-import { workflow } from 'pg-workflows'
-import * as v from 'valibot'
+import { workflow } from "pg-workflows";
+import * as v from "valibot";
 
 const myWorkflow = workflow(
-  'user-onboarding',
+  "user-onboarding",
   async ({ step, input }) => {
     // input is typed as { email: string; name: string }
-    await step.run('send-welcome', async () => {
-      return await sendEmail(input.email, `Welcome, ${input.name}!`)
-    })
+    await step.run("send-welcome", async () => {
+      return await sendEmail(input.email, `Welcome, ${input.name}!`);
+    });
   },
   {
     inputSchema: v.object({
@@ -235,7 +265,7 @@ const myWorkflow = workflow(
       name: v.string(),
     }),
   },
-)
+);
 ```
 
 ### Without a Schema
@@ -243,37 +273,34 @@ const myWorkflow = workflow(
 When no `inputSchema` is provided, input is not validated and `input` is typed as `unknown`. The engine has no guarantee about the shape of the data — it passes through whatever was provided to `startWorkflow()`. You are responsible for narrowing the type yourself:
 
 ```typescript
-import { workflow } from 'pg-workflows'
+import { workflow } from "pg-workflows";
 
-const myWorkflow = workflow(
-  'process-order',
-  async ({ step, input }) => {
-    // Option 1: Type assertion - you trust the caller
-    const { orderId, amount } = input as { orderId: string; amount: number }
+const myWorkflow = workflow("process-order", async ({ step, input }) => {
+  // Option 1: Type assertion - you trust the caller
+  const { orderId, amount } = input as { orderId: string; amount: number };
 
-    await step.run('charge', async () => {
-      return await chargeOrder(orderId, amount)
-    })
-  },
-)
+  await step.run("charge", async () => {
+    return await chargeOrder(orderId, amount);
+  });
+});
 
 const myDefensiveWorkflow = workflow(
-  'process-order-safe',
+  "process-order-safe",
   async ({ step, input }) => {
     // Option 2: Runtime checks - you verify before using
-    if (typeof input !== 'object' || input === null) {
-      throw new Error('Expected input to be an object')
+    if (typeof input !== "object" || input === null) {
+      throw new Error("Expected input to be an object");
     }
-    const { orderId, amount } = input as Record<string, unknown>
-    if (typeof orderId !== 'string' || typeof amount !== 'number') {
-      throw new Error('Invalid input shape')
+    const { orderId, amount } = input as Record<string, unknown>;
+    if (typeof orderId !== "string" || typeof amount !== "number") {
+      throw new Error("Invalid input shape");
     }
 
-    await step.run('charge', async () => {
-      return await chargeOrder(orderId, amount)
-    })
+    await step.run("charge", async () => {
+      return await chargeOrder(orderId, amount);
+    });
   },
-)
+);
 ```
 
 Using an `inputSchema` is recommended — it validates input at the engine boundary before your handler runs, and gives you full type inference with no manual work.

--- a/src/ast-parser.test.ts
+++ b/src/ast-parser.test.ts
@@ -161,12 +161,12 @@ describe('AST Parser for Workflow Steps', () => {
     ]);
   });
 
-  it('should parse invokeWorkflow steps', async () => {
+  it('should parse invokeChildWorkflow steps', async () => {
     const childWorkflow = workflow('parser-child-workflow', async ({ step }) => {
       return await step.run('child-step', async () => 'child-result');
     });
     const parentWorkflow = workflow('parser-parent-workflow', async ({ step }) => {
-      await step.invokeWorkflow('call-child', {
+      await step.invokeChildWorkflow('call-child', {
         workflowId: 'parser-child-workflow',
         input: {},
       });
@@ -180,7 +180,7 @@ describe('AST Parser for Workflow Steps', () => {
     expect(engine.workflows.get('parser-parent-workflow')?.steps).toEqual([
       {
         id: 'call-child',
-        type: StepType.INVOKE_WORKFLOW,
+        type: StepType.INVOKE_CHILD_WORKFLOW,
         conditional: false,
         loop: false,
         isDynamic: false,

--- a/src/ast-parser.test.ts
+++ b/src/ast-parser.test.ts
@@ -161,6 +161,33 @@ describe('AST Parser for Workflow Steps', () => {
     ]);
   });
 
+  it('should parse invokeWorkflow steps', async () => {
+    const childWorkflow = workflow('parser-child-workflow', async ({ step }) => {
+      return await step.run('child-step', async () => 'child-result');
+    });
+    const parentWorkflow = workflow('parser-parent-workflow', async ({ step }) => {
+      await step.invokeWorkflow('call-child', {
+        workflowId: 'parser-child-workflow',
+        input: {},
+      });
+      return 'completed';
+    });
+
+    const engine = new WorkflowEngine({ pool: testPool, boss: testBoss });
+    await engine.registerWorkflow(childWorkflow);
+    await engine.registerWorkflow(parentWorkflow);
+
+    expect(engine.workflows.get('parser-parent-workflow')?.steps).toEqual([
+      {
+        id: 'call-child',
+        type: StepType.INVOKE_WORKFLOW,
+        conditional: false,
+        loop: false,
+        isDynamic: false,
+      },
+    ]);
+  });
+
   it('should handle workflow with waitFor and pause steps', async () => {
     const mixedStepWorkflow = workflow('mixed-step-workflow', async ({ step }) => {
       await step.run('step-1', async () => 'result-1');

--- a/src/ast-parser.ts
+++ b/src/ast-parser.ts
@@ -81,7 +81,8 @@ export function parseWorkflowHandler(
           methodName === 'waitUntil' ||
           methodName === 'delay' ||
           methodName === 'sleep' ||
-          methodName === 'poll')
+          methodName === 'poll' ||
+          methodName === 'invokeWorkflow')
       ) {
         const firstArg = node.arguments[0];
         if (firstArg) {

--- a/src/ast-parser.ts
+++ b/src/ast-parser.ts
@@ -82,7 +82,7 @@ export function parseWorkflowHandler(
           methodName === 'delay' ||
           methodName === 'sleep' ||
           methodName === 'poll' ||
-          methodName === 'invokeWorkflow')
+          methodName === 'invokeChildWorkflow')
       ) {
         const firstArg = node.arguments[0];
         if (firstArg) {

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -138,7 +138,7 @@ describe('WorkflowClient', () => {
   });
 
   describe('fastForwardWorkflow', () => {
-    it('should no-op for invokeWorkflow waits', async () => {
+    it('should no-op for invokeChildWorkflow waits', async () => {
       const run = await client.startWorkflow({
         resourceId,
         workflowId: 'client-fast-forward-invoke',
@@ -154,8 +154,8 @@ describe('WorkflowClient', () => {
           'call-child',
           new Date(),
           JSON.stringify({
-            'call-child-invoke-workflow': {
-              invokeWorkflow: {
+            'call-child-invoke-child-workflow': {
+              invokeChildWorkflow: {
                 childRunId: 'run_child_for_client_fast_forward',
                 childWorkflowId: 'client-child-workflow',
               },
@@ -163,7 +163,7 @@ describe('WorkflowClient', () => {
             },
             'call-child-wait-for': {
               waitFor: {
-                eventName: '__invoke_workflow_completed:run_child_for_client_fast_forward',
+                eventName: '__invoke_child_workflow_completed:run_child_for_client_fast_forward',
               },
               timestamp: new Date().toISOString(),
             },

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -1,10 +1,11 @@
 import type pg from 'pg';
 import { PgBoss } from 'pg-boss';
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 import { WorkflowClient } from './client';
 import { createWorkflowRef } from './definition';
 import { closeTestDatabase, createTestDatabase } from './tests/test-db';
+import { WorkflowStatus } from './types';
 
 let testPool: pg.Pool;
 
@@ -133,6 +134,68 @@ describe('WorkflowClient', () => {
       expect(schemas.rows).toHaveLength(1);
 
       await customClient.stop();
+    });
+  });
+
+  describe('fastForwardWorkflow', () => {
+    it('should no-op for invokeWorkflow waits', async () => {
+      const run = await client.startWorkflow({
+        resourceId,
+        workflowId: 'client-fast-forward-invoke',
+        input: {},
+      });
+
+      await testPool.query(
+        `UPDATE workflow_runs
+         SET status = $1, current_step_id = $2, paused_at = $3, timeline = $4
+         WHERE id = $5`,
+        [
+          WorkflowStatus.PAUSED,
+          'call-child',
+          new Date(),
+          JSON.stringify({
+            'call-child-invoke-workflow': {
+              invokeWorkflow: {
+                childRunId: 'run_child_for_client_fast_forward',
+                childWorkflowId: 'client-child-workflow',
+              },
+              timestamp: new Date().toISOString(),
+            },
+            'call-child-wait-for': {
+              waitFor: {
+                eventName: '__invoke_workflow_completed:run_child_for_client_fast_forward',
+              },
+              timestamp: new Date().toISOString(),
+            },
+          }),
+          run.id,
+        ],
+      );
+
+      const boss = (client as unknown as { boss: PgBoss }).boss;
+      const sendSpy = vi.spyOn(boss, 'send');
+      try {
+        const resumeResult = await client.resumeWorkflow({
+          runId: run.id,
+          resourceId,
+        });
+        expect(resumeResult.status).toBe(WorkflowStatus.PAUSED);
+        expect(sendSpy).not.toHaveBeenCalled();
+      } finally {
+        sendSpy.mockRestore();
+      }
+
+      const result = await client.fastForwardWorkflow({
+        runId: run.id,
+        resourceId,
+        data: { fake: true },
+      });
+
+      expect(result.status).toBe(WorkflowStatus.PAUSED);
+
+      const current = await client.getRun({ runId: run.id, resourceId });
+      expect(current.status).toBe(WorkflowStatus.PAUSED);
+      expect(current.timeline).not.toHaveProperty('call-child.output');
     });
   });
 });

--- a/src/client.ts
+++ b/src/client.ts
@@ -335,7 +335,8 @@ export class WorkflowClient {
     }
 
     const currentStepId = current.currentStepId;
-    const currentStepTimelineEntry = current.timeline[invokeChildWorkflowTimelineKey(currentStepId)];
+    const currentStepTimelineEntry =
+      current.timeline[invokeChildWorkflowTimelineKey(currentStepId)];
     if (isInvokeChildWorkflowTimelineEntry(currentStepTimelineEntry)) {
       return current;
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -22,6 +22,7 @@ import {
   type InputParameters,
   type WorkflowLogger,
   type WorkflowRef,
+  type WorkflowRunOptions,
   type WorkflowRunProgress,
   WorkflowStatus,
 } from './types';
@@ -50,13 +51,7 @@ export type WorkflowClientOptions = {
   boss?: PgBoss;
 } & ({ pool: pg.Pool; connectionString?: never } | { connectionString: string; pool?: never });
 
-export type StartWorkflowOptions = {
-  resourceId?: string;
-  timeout?: number;
-  retries?: number;
-  expireInSeconds?: number;
-  idempotencyKey?: string;
-};
+export type StartWorkflowOptions = WorkflowRunOptions;
 
 const defaultLogger: WorkflowLogger = {
   log: (_message: string) => console.warn(_message),
@@ -327,6 +322,16 @@ export class WorkflowClient {
       );
     }
 
+    const stepId = current.currentStepId;
+    const invokeWorkflowEntry = current.timeline[`${stepId}-invoke-workflow`];
+    if (
+      invokeWorkflowEntry &&
+      typeof invokeWorkflowEntry === 'object' &&
+      'invokeWorkflow' in invokeWorkflowEntry
+    ) {
+      return current;
+    }
+
     return this.triggerEvent({
       runId,
       resourceId,
@@ -354,6 +359,15 @@ export class WorkflowClient {
     }
 
     const stepId = run.currentStepId;
+    const invokeWorkflowEntry = run.timeline[`${stepId}-invoke-workflow`];
+    if (
+      invokeWorkflowEntry &&
+      typeof invokeWorkflowEntry === 'object' &&
+      'invokeWorkflow' in invokeWorkflowEntry
+    ) {
+      return run;
+    }
+
     const waitForEntry = run.timeline[`${stepId}-wait-for`];
     if (!waitForEntry || typeof waitForEntry !== 'object' || !('waitFor' in waitForEntry)) {
       return run;

--- a/src/client.ts
+++ b/src/client.ts
@@ -3,8 +3,8 @@ import pg from 'pg';
 import { type Db, PgBoss } from 'pg-boss';
 import {
   DEFAULT_PGBOSS_SCHEMA,
-  invokeWorkflowTimelineKey,
-  isInvokeWorkflowTimelineEntry,
+  invokeChildWorkflowTimelineKey,
+  isInvokeChildWorkflowTimelineEntry,
   PAUSE_EVENT_NAME,
   WORKFLOW_RUN_QUEUE_NAME,
   waitForTimelineKey,
@@ -334,8 +334,9 @@ export class WorkflowClient {
       );
     }
 
-    const stepId = current.currentStepId;
-    if (isInvokeWorkflowTimelineEntry(current.timeline[invokeWorkflowTimelineKey(stepId)])) {
+    const currentStepId = current.currentStepId;
+    const currentStepTimelineEntry = current.timeline[invokeChildWorkflowTimelineKey(currentStepId)];
+    if (isInvokeChildWorkflowTimelineEntry(currentStepTimelineEntry)) {
       return current;
     }
 
@@ -365,12 +366,13 @@ export class WorkflowClient {
       return run;
     }
 
-    const stepId = run.currentStepId;
-    if (isInvokeWorkflowTimelineEntry(run.timeline[invokeWorkflowTimelineKey(stepId)])) {
+    const currentStepId = run.currentStepId;
+    const currentStepTimelineEntry = run.timeline[invokeChildWorkflowTimelineKey(currentStepId)];
+    if (isInvokeChildWorkflowTimelineEntry(currentStepTimelineEntry)) {
       return run;
     }
 
-    const waitForEntry = run.timeline[waitForTimelineKey(stepId)];
+    const waitForEntry = run.timeline[waitForTimelineKey(currentStepId)];
     if (!waitForEntry || typeof waitForEntry !== 'object' || !('waitFor' in waitForEntry)) {
       return run;
     }
@@ -397,7 +399,7 @@ export class WorkflowClient {
               resourceId,
               data: {
                 timeline: merge(freshRun.timeline, {
-                  [stepId]: {
+                  [currentStepId]: {
                     output: data ?? {},
                     timestamp: new Date(),
                   },

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,7 +1,14 @@
 import { merge } from 'es-toolkit';
 import pg from 'pg';
 import { type Db, PgBoss } from 'pg-boss';
-import { DEFAULT_PGBOSS_SCHEMA, PAUSE_EVENT_NAME, WORKFLOW_RUN_QUEUE_NAME } from './constants';
+import {
+  DEFAULT_PGBOSS_SCHEMA,
+  invokeWorkflowTimelineKey,
+  isInvokeWorkflowTimelineEntry,
+  PAUSE_EVENT_NAME,
+  WORKFLOW_RUN_QUEUE_NAME,
+  waitForTimelineKey,
+} from './constants';
 import { runMigrations } from './db/migration';
 import {
   getWorkflowRun,
@@ -220,9 +227,14 @@ export class WorkflowClient {
             input,
           };
 
+          // Same connection (`_db`) used for the workflow_runs INSERT is passed
+          // to `boss.send` so the pgboss.job INSERT joins the same transaction.
+          // The two writes commit or roll back together, so we never leak an
+          // orphan workflow_runs row when the queue insert fails.
           await this.boss.send(WORKFLOW_RUN_QUEUE_NAME, job, {
             startAfter: new Date(),
             expireInSeconds: options?.expireInSeconds ?? defaultExpireInSeconds,
+            db: _db,
           });
         }
 
@@ -323,12 +335,7 @@ export class WorkflowClient {
     }
 
     const stepId = current.currentStepId;
-    const invokeWorkflowEntry = current.timeline[`${stepId}-invoke-workflow`];
-    if (
-      invokeWorkflowEntry &&
-      typeof invokeWorkflowEntry === 'object' &&
-      'invokeWorkflow' in invokeWorkflowEntry
-    ) {
+    if (isInvokeWorkflowTimelineEntry(current.timeline[invokeWorkflowTimelineKey(stepId)])) {
       return current;
     }
 
@@ -359,16 +366,11 @@ export class WorkflowClient {
     }
 
     const stepId = run.currentStepId;
-    const invokeWorkflowEntry = run.timeline[`${stepId}-invoke-workflow`];
-    if (
-      invokeWorkflowEntry &&
-      typeof invokeWorkflowEntry === 'object' &&
-      'invokeWorkflow' in invokeWorkflowEntry
-    ) {
+    if (isInvokeWorkflowTimelineEntry(run.timeline[invokeWorkflowTimelineKey(stepId)])) {
       return run;
     }
 
-    const waitForEntry = run.timeline[`${stepId}-wait-for`];
+    const waitForEntry = run.timeline[waitForTimelineKey(stepId)];
     if (!waitForEntry || typeof waitForEntry !== 'object' || !('waitFor' in waitForEntry)) {
       return run;
     }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,3 +4,23 @@ export const WORKFLOW_RUN_DLQ_QUEUE_NAME = 'workflow_run_dlq';
 export const DEFAULT_PGBOSS_SCHEMA = 'pgboss_v12_pgworkflow';
 export const MAX_WORKFLOW_ID_LENGTH = 256;
 export const MAX_RESOURCE_ID_LENGTH = 256;
+
+// Per-step timeline key suffixes. The shared helpers below are the single
+// source of truth for engine + client so timeline-shape changes only need to
+// happen in one place.
+export const INVOKE_WORKFLOW_TIMELINE_SUFFIX = 'invoke-workflow';
+export const WAIT_FOR_TIMELINE_SUFFIX = 'wait-for';
+export const invokeWorkflowTimelineKey = (stepId: string) =>
+  `${stepId}-${INVOKE_WORKFLOW_TIMELINE_SUFFIX}`;
+export const waitForTimelineKey = (stepId: string) => `${stepId}-${WAIT_FOR_TIMELINE_SUFFIX}`;
+
+/**
+ * Type guard for `${stepId}-invoke-workflow` timeline entries. Used by the
+ * engine to dispatch invoke-aware behavior and by the client's resume /
+ * fast-forward no-op guards. Centralizing this keeps the timeline shape
+ * contract in one place.
+ */
+export const isInvokeWorkflowTimelineEntry = (
+  entry: unknown,
+): entry is { invokeWorkflow: { childRunId: string; childWorkflowId: string } } =>
+  !!entry && typeof entry === 'object' && 'invokeWorkflow' in entry;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,19 +8,19 @@ export const MAX_RESOURCE_ID_LENGTH = 256;
 // Per-step timeline key suffixes. The shared helpers below are the single
 // source of truth for engine + client so timeline-shape changes only need to
 // happen in one place.
-export const INVOKE_WORKFLOW_TIMELINE_SUFFIX = 'invoke-workflow';
+export const INVOKE_CHILD_WORKFLOW_TIMELINE_SUFFIX = 'invoke-child-workflow';
 export const WAIT_FOR_TIMELINE_SUFFIX = 'wait-for';
-export const invokeWorkflowTimelineKey = (stepId: string) =>
-  `${stepId}-${INVOKE_WORKFLOW_TIMELINE_SUFFIX}`;
+export const invokeChildWorkflowTimelineKey = (stepId: string) =>
+  `${stepId}-${INVOKE_CHILD_WORKFLOW_TIMELINE_SUFFIX}`;
 export const waitForTimelineKey = (stepId: string) => `${stepId}-${WAIT_FOR_TIMELINE_SUFFIX}`;
 
 /**
- * Type guard for `${stepId}-invoke-workflow` timeline entries. Used by the
+ * Type guard for `${stepId}-invoke-child-workflow` timeline entries. Used by the
  * engine to dispatch invoke-aware behavior and by the client's resume /
  * fast-forward no-op guards. Centralizing this keeps the timeline shape
  * contract in one place.
  */
-export const isInvokeWorkflowTimelineEntry = (
+export const isInvokeChildWorkflowTimelineEntry = (
   entry: unknown,
-): entry is { invokeWorkflow: { childRunId: string; childWorkflowId: string } } =>
-  !!entry && typeof entry === 'object' && 'invokeWorkflow' in entry;
+): entry is { invokeChildWorkflow: { childRunId: string; childWorkflowId: string } } =>
+  !!entry && typeof entry === 'object' && 'invokeChildWorkflow' in entry;

--- a/src/db/migration.ts
+++ b/src/db/migration.ts
@@ -5,7 +5,7 @@ export const MIGRATION_LOCK_ID = 738291645;
 
 // Bump this when adding new migrations. The engine stores the current version
 // in a `workflow_schema_version` table so migrations only run once per version.
-const CURRENT_SCHEMA_VERSION = 3;
+const CURRENT_SCHEMA_VERSION = 4;
 
 export async function runMigrations(db: Db): Promise<void> {
   // Fast path: skip the advisory lock if schema is already current.
@@ -77,6 +77,14 @@ export async function runMigrations(db: Db): Promise<void> {
   if (currentVersion < 3) {
     commands.push('ALTER TABLE workflow_runs ALTER COLUMN resource_id TYPE varchar(256)');
     commands.push('ALTER TABLE workflow_runs ALTER COLUMN workflow_id TYPE varchar(256)');
+  }
+
+  if (currentVersion < 4) {
+    commands.push('ALTER TABLE workflow_runs ADD COLUMN IF NOT EXISTS parent_run_id varchar(32)');
+    commands.push('ALTER TABLE workflow_runs ADD COLUMN IF NOT EXISTS parent_step_id varchar(256)');
+    commands.push(
+      'ALTER TABLE workflow_runs ADD COLUMN IF NOT EXISTS parent_resource_id varchar(256)',
+    );
   }
 
   // Upsert the schema version

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -26,6 +26,9 @@ type WorkflowRunRow = {
   max_retries: number;
   job_id: string | null;
   idempotency_key: string | null;
+  parent_run_id: string | null;
+  parent_step_id: string | null;
+  parent_resource_id: string | null;
 };
 
 function mapRowToWorkflowRun(row: WorkflowRunRow): WorkflowRun {
@@ -54,6 +57,9 @@ function mapRowToWorkflowRun(row: WorkflowRunRow): WorkflowRun {
     maxRetries: row.max_retries,
     jobId: row.job_id,
     idempotencyKey: row.idempotency_key,
+    parentRunId: row.parent_run_id,
+    parentStepId: row.parent_step_id,
+    parentResourceId: row.parent_resource_id,
   };
 }
 
@@ -67,6 +73,9 @@ export async function insertWorkflowRun(
     maxRetries,
     timeoutAt,
     idempotencyKey,
+    parentRunId,
+    parentStepId,
+    parentResourceId,
   }: {
     resourceId?: string;
     workflowId: string;
@@ -76,6 +85,9 @@ export async function insertWorkflowRun(
     maxRetries: number;
     timeoutAt: Date | null;
     idempotencyKey?: string;
+    parentRunId?: string;
+    parentStepId?: string;
+    parentResourceId?: string;
   },
   db: Db,
 ): Promise<{ run: WorkflowRun; created: boolean }> {
@@ -96,9 +108,12 @@ export async function insertWorkflowRun(
       updated_at,
       timeline,
       retry_count,
-      idempotency_key
+      idempotency_key,
+      parent_run_id,
+      parent_step_id,
+      parent_resource_id
     )
-    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
     ON CONFLICT (idempotency_key) WHERE idempotency_key IS NOT NULL DO NOTHING
     RETURNING *`,
     [
@@ -115,6 +130,9 @@ export async function insertWorkflowRun(
       '{}',
       0,
       idempotencyKey ?? null,
+      parentRunId ?? null,
+      parentStepId ?? null,
+      parentResourceId ?? null,
     ],
   );
 

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -18,4 +18,7 @@ export type WorkflowRun = {
   maxRetries: number;
   jobId: string | null;
   idempotencyKey: string | null;
+  parentRunId: string | null;
+  parentStepId: string | null;
+  parentResourceId: string | null;
 };

--- a/src/definition.ts
+++ b/src/definition.ts
@@ -13,12 +13,17 @@ import type {
  * Create a lightweight workflow reference.
  * Safe to import from `pg-workflows/client` - no engine or handler code.
  */
-export function createWorkflowRef<TInput extends InputParameters = InputParameters>(
+export function createWorkflowRef<
+  TOutput = unknown,
+  TInput extends InputParameters = InputParameters,
+>(
   id: string,
   options?: { inputSchema?: TInput },
-): WorkflowRef<TInput> {
+): WorkflowRef<TInput, TOutput> {
   const ref = ((
-    handler: (context: WorkflowContext<TInput, StepBaseContext>) => Promise<unknown>,
+    handler: (
+      context: WorkflowContext<TInput, StepBaseContext>,
+    ) => Promise<unknown>,
     defineOptions?: Omit<WorkflowOptions<TInput>, 'inputSchema'>,
   ): WorkflowDefinition<TInput> => ({
     id,
@@ -28,10 +33,13 @@ export function createWorkflowRef<TInput extends InputParameters = InputParamete
     inputSchema: options?.inputSchema,
     timeout: defineOptions?.timeout,
     retries: defineOptions?.retries,
-  })) as WorkflowRef<TInput>;
+  })) as WorkflowRef<TInput, TOutput>;
 
   Object.defineProperty(ref, 'id', { value: id, enumerable: true });
-  Object.defineProperty(ref, 'inputSchema', { value: options?.inputSchema, enumerable: true });
+  Object.defineProperty(ref, 'inputSchema', {
+    value: options?.inputSchema,
+    enumerable: true,
+  });
 
   return ref;
 }
@@ -41,7 +49,9 @@ function createWorkflowFactory<TStepExt extends object = object>(
 ): WorkflowFactory<TStepExt> {
   const factory = (<I extends InputParameters>(
     id: string,
-    handler: (context: WorkflowContext<I, StepBaseContext & TStepExt>) => Promise<unknown>,
+    handler: (
+      context: WorkflowContext<I, StepBaseContext & TStepExt>,
+    ) => Promise<unknown>,
     { inputSchema, timeout, retries }: WorkflowOptions<I> = {},
   ): WorkflowDefinition<I> => ({
     id,

--- a/src/definition.ts
+++ b/src/definition.ts
@@ -16,14 +16,9 @@ import type {
 export function createWorkflowRef<
   TOutput = unknown,
   TInput extends InputParameters = InputParameters,
->(
-  id: string,
-  options?: { inputSchema?: TInput },
-): WorkflowRef<TInput, TOutput> {
+>(id: string, options?: { inputSchema?: TInput }): WorkflowRef<TInput, TOutput> {
   const ref = ((
-    handler: (
-      context: WorkflowContext<TInput, StepBaseContext>,
-    ) => Promise<unknown>,
+    handler: (context: WorkflowContext<TInput, StepBaseContext>) => Promise<unknown>,
     defineOptions?: Omit<WorkflowOptions<TInput>, 'inputSchema'>,
   ): WorkflowDefinition<TInput> => ({
     id,
@@ -49,9 +44,7 @@ function createWorkflowFactory<TStepExt extends object = object>(
 ): WorkflowFactory<TStepExt> {
   const factory = (<I extends InputParameters>(
     id: string,
-    handler: (
-      context: WorkflowContext<I, StepBaseContext & TStepExt>,
-    ) => Promise<unknown>,
+    handler: (context: WorkflowContext<I, StepBaseContext & TStepExt>) => Promise<unknown>,
     { inputSchema, timeout, retries }: WorkflowOptions<I> = {},
   ): WorkflowDefinition<I> => ({
     id,

--- a/src/engine.test.ts
+++ b/src/engine.test.ts
@@ -916,7 +916,7 @@ describe('WorkflowEngine', () => {
       });
 
       const parentWorkflow = workflow('invoke-parent-success', async ({ step }) => {
-        const childOutput = await step.invokeWorkflow<{ child: { message: string } }>(
+        const childOutput = await step.invokeChildWorkflow<{ child: { message: string } }>(
           'call-child',
           {
             workflowId: 'invoke-child-success',
@@ -941,8 +941,8 @@ describe('WorkflowEngine', () => {
           status: WorkflowStatus.PAUSED,
           currentStepId: 'call-child',
           timeline: {
-            'call-child-invoke-workflow': {
-              invokeWorkflow: {
+            'call-child-invoke-child-workflow': {
+              invokeChildWorkflow: {
                 childWorkflowId: 'invoke-child-success',
               },
             },
@@ -1001,7 +1001,7 @@ describe('WorkflowEngine', () => {
       });
 
       const parentWorkflow = workflow('invoke-parent-post-commit', async ({ step }) => {
-        return await step.invokeWorkflow('call-child', {
+        return await step.invokeChildWorkflow('call-child', {
           workflowId: 'invoke-child-post-commit',
           input: {},
         });
@@ -1026,15 +1026,15 @@ describe('WorkflowEngine', () => {
             });
             expect(parentRun.status).toBe(WorkflowStatus.PAUSED);
             expect(parentRun.timeline).toMatchObject({
-              'call-child-invoke-workflow': {
-                invokeWorkflow: {
+              'call-child-invoke-child-workflow': {
+                invokeChildWorkflow: {
                   childRunId: childRun.id,
                   childWorkflowId: 'invoke-child-post-commit',
                 },
               },
               'call-child-wait-for': {
                 waitFor: {
-                  eventName: `__invoke_workflow_completed:${childRun.id}`,
+                  eventName: `__invoke_child_workflow_completed:${childRun.id}`,
                   skipOutput: true,
                 },
               },
@@ -1067,7 +1067,7 @@ describe('WorkflowEngine', () => {
       });
 
       const parentWorkflow = workflow('invoke-parent-null-output', async ({ step }) => {
-        const childOutput = await step.invokeWorkflow<null>('call-child', {
+        const childOutput = await step.invokeChildWorkflow<null>('call-child', {
           workflowId: 'invoke-child-null-output',
           input: {},
         });
@@ -1105,7 +1105,7 @@ describe('WorkflowEngine', () => {
       });
 
       const parentWorkflow = workflow('invoke-parent-idempotent', async ({ step }) => {
-        return await step.invokeWorkflow('call-child', {
+        return await step.invokeChildWorkflow('call-child', {
           workflowId: 'invoke-child-idempotent',
           input: {},
         });
@@ -1140,7 +1140,7 @@ describe('WorkflowEngine', () => {
       expect(childRuns.items[0].idempotencyKey).toBeNull();
     });
 
-    it('should return invokeWorkflow output cached after acquiring the parent lock', async () => {
+    it('should return invokeChildWorkflow output cached after acquiring the parent lock', async () => {
       const now = new Date();
       const parentRun: WorkflowRun = {
         id: 'invoke-parent-lock-race',
@@ -1175,8 +1175,8 @@ describe('WorkflowEngine', () => {
           },
         },
       };
-      const engineWithInvokeWorkflowStep = engine as unknown as {
-        invokeWorkflowStep(args: {
+      const engineWithInvokeChildWorkflowStep = engine as unknown as {
+        invokeChildWorkflowStep(args: {
           run: WorkflowRun;
           stepId: string;
           workflowId: string;
@@ -1189,7 +1189,7 @@ describe('WorkflowEngine', () => {
 
       try {
         await expect(
-          engineWithInvokeWorkflowStep.invokeWorkflowStep({
+          engineWithInvokeChildWorkflowStep.invokeChildWorkflowStep({
             run: parentRun,
             stepId: 'call-child',
             workflowId: 'invoke-child-lock-race',
@@ -1254,8 +1254,8 @@ describe('WorkflowEngine', () => {
       const lockedParentRun: WorkflowRun = {
         ...parentRun,
         timeline: {
-          'call-child-invoke-workflow': {
-            invokeWorkflow: {
+          'call-child-invoke-child-workflow': {
+            invokeChildWorkflow: {
               childRunId: childRun.id,
               childWorkflowId: childRun.workflowId,
               childResourceId: childRun.resourceId,
@@ -1264,8 +1264,8 @@ describe('WorkflowEngine', () => {
           },
         },
       };
-      const engineWithInvokeWorkflowStep = engine as unknown as {
-        invokeWorkflowStep(args: {
+      const engineWithInvokeChildWorkflowStep = engine as unknown as {
+        invokeChildWorkflowStep(args: {
           run: WorkflowRun;
           stepId: string;
           workflowId: string;
@@ -1290,7 +1290,7 @@ describe('WorkflowEngine', () => {
 
       try {
         await expect(
-          engineWithInvokeWorkflowStep.invokeWorkflowStep({
+          engineWithInvokeChildWorkflowStep.invokeChildWorkflowStep({
             run: parentRun,
             stepId: 'call-child',
             workflowId: childRun.workflowId,
@@ -1312,7 +1312,7 @@ describe('WorkflowEngine', () => {
       });
 
       const parentWorkflow = workflow('invoke-parent-key-conflict', async ({ step }) => {
-        await step.invokeWorkflow('call-child', {
+        await step.invokeChildWorkflow('call-child', {
           workflowId: 'invoke-child-key-conflict',
           input: {},
           idempotencyKey: 'invoke-child-conflict-key',
@@ -1346,7 +1346,7 @@ describe('WorkflowEngine', () => {
         })
         .toMatchObject({
           status: WorkflowStatus.FAILED,
-          error: expect.stringContaining('does not belong to invokeWorkflow step'),
+          error: expect.stringContaining('does not belong to invokeChildWorkflow step'),
         });
     });
 
@@ -1356,7 +1356,7 @@ describe('WorkflowEngine', () => {
       });
 
       const parentWorkflow = workflow('invoke-parent-enqueue-retry', async ({ step }) => {
-        return await step.invokeWorkflow('call-child', {
+        return await step.invokeChildWorkflow('call-child', {
           workflowId: 'invoke-child-enqueue-retry',
           input: {},
         });
@@ -1423,7 +1423,7 @@ describe('WorkflowEngine', () => {
       });
 
       const parentWorkflow = workflow('invoke-parent-child-fails', async ({ step }) => {
-        await step.invokeWorkflow('call-child', {
+        await step.invokeChildWorkflow('call-child', {
           workflowId: 'invoke-child-fails',
           input: {},
         });
@@ -1458,7 +1458,7 @@ describe('WorkflowEngine', () => {
       });
 
       const parentWorkflow = workflow('invoke-parent-child-cancelled', async ({ step }) => {
-        await step.invokeWorkflow('call-child', {
+        await step.invokeChildWorkflow('call-child', {
           workflowId: 'invoke-child-cancelled',
           input: {},
         });
@@ -1495,14 +1495,14 @@ describe('WorkflowEngine', () => {
       expect(failedParent.timeline).not.toHaveProperty('call-child.output');
     });
 
-    it('should ignore fastForwardWorkflow on invokeWorkflow waits and only resume via the real child completion', async () => {
+    it('should ignore fastForwardWorkflow on invokeChildWorkflow waits and only resume via the real child completion', async () => {
       const childWorkflow = workflow('invoke-child-ff-after-complete', async ({ step }) => {
         await step.waitFor('child-wait', { eventName: 'child-ready' });
         return { ok: true };
       });
 
       const parentWorkflow = workflow('invoke-parent-ff-after-complete', async ({ step }) => {
-        return await step.invokeWorkflow('call-child', {
+        return await step.invokeChildWorkflow('call-child', {
           workflowId: 'invoke-child-ff-after-complete',
           input: {},
         });
@@ -1528,7 +1528,7 @@ describe('WorkflowEngine', () => {
       expect(childRuns.items).toHaveLength(1);
       const childRun = childRuns.items[0];
 
-      // Calling fastForwardWorkflow on an invokeWorkflow wait must always be a
+      // Calling fastForwardWorkflow on an invokeChildWorkflow wait must always be a
       // no-op; only the real invoke-completion event drives the parent forward.
       const ffWhilePending = await engine.fastForwardWorkflow({
         runId: parentRun.id,
@@ -1560,7 +1560,7 @@ describe('WorkflowEngine', () => {
       });
 
       const parentWorkflow = workflow('invoke-parent-parent-timeout', async ({ step }) => {
-        return await step.invokeWorkflow('call-child', {
+        return await step.invokeChildWorkflow('call-child', {
           workflowId: 'invoke-child-parent-timeout',
           input: {},
         });
@@ -1623,7 +1623,7 @@ describe('WorkflowEngine', () => {
       });
 
       const parentWorkflow = workflow('invoke-parent-duplicate-wakeup', async ({ step }) => {
-        const childOutput = await step.invokeWorkflow<{ value: string }>('call-child', {
+        const childOutput = await step.invokeChildWorkflow<{ value: string }>('call-child', {
           workflowId: 'invoke-child-duplicate-wakeup',
           input: {},
         });
@@ -1672,7 +1672,7 @@ describe('WorkflowEngine', () => {
       // wait-for unlock branch, fall through to the (now no-op) handler path,
       // and never overwrite the cached output. This guards the
       // "child notify fires twice (catch + DLQ)" deduplication path.
-      const eventName = `__invoke_workflow_completed:${childRun.id}`;
+      const eventName = `__invoke_child_workflow_completed:${childRun.id}`;
       await testBoss.send(WORKFLOW_RUN_QUEUE_NAME, {
         runId: parentRun.id,
         resourceId,
@@ -3040,14 +3040,14 @@ describe('WorkflowEngine', () => {
         });
     });
 
-    it('should not fast-forward an invokeWorkflow step while the child is still running', async () => {
+    it('should not fast-forward an invokeChildWorkflow step while the child is still running', async () => {
       const childWorkflow = workflow('ff-method-invoke-child', async ({ step }) => {
         await step.waitFor('child-wait', { eventName: 'child-ready' });
         return { ok: true };
       });
 
       const parentWorkflow = workflow('ff-method-invoke-parent', async ({ step }) => {
-        return await step.invokeWorkflow('call-child', {
+        return await step.invokeChildWorkflow('call-child', {
           workflowId: 'ff-method-invoke-child',
           input: {},
         });

--- a/src/engine.test.ts
+++ b/src/engine.test.ts
@@ -539,6 +539,60 @@ describe('WorkflowEngine', () => {
         expect(run2.idempotencyKey).toBe('key-b');
       });
     });
+
+    it('should fall back to options.resourceId / options.idempotencyKey when not passed at the top level', async () => {
+      // Documents the resolveWorkflowRunParameters behavior: for the params-
+      // object form, `resourceId` and `idempotencyKey` may be supplied either
+      // at the top level OR nested in `options`, and the top level wins.
+      const run = await engine.startWorkflow({
+        workflowId: 'test-workflow',
+        input: { data: 'options-fallback' },
+        options: {
+          resourceId: 'options-resource',
+          idempotencyKey: 'options-fallback-key',
+        },
+      });
+
+      expect(run.resourceId).toBe('options-resource');
+      expect(run.idempotencyKey).toBe('options-fallback-key');
+
+      const sameRun = await engine.startWorkflow({
+        workflowId: 'test-workflow',
+        input: { data: 'options-fallback-2' },
+        options: {
+          resourceId: 'options-resource',
+          idempotencyKey: 'options-fallback-key',
+        },
+      });
+      expect(sameRun.id).toBe(run.id);
+    });
+
+    it('should roll back the workflow_runs insert when boss.send fails', async () => {
+      const sendSpy = vi.spyOn(testBoss, 'send').mockImplementation(async () => {
+        throw new Error('simulated boss.send failure');
+      });
+
+      try {
+        await expect(
+          engine.startWorkflow({
+            resourceId,
+            workflowId: 'test-workflow',
+            input: { data: 'rollback-me' },
+            idempotencyKey: 'rollback-test-key',
+          }),
+        ).rejects.toThrow('simulated boss.send failure');
+      } finally {
+        sendSpy.mockRestore();
+      }
+
+      // The transactional send means the workflow_runs row must NOT exist
+      // because the boss.send failure rolled back the parent transaction.
+      const remaining = await testPool.query(
+        'SELECT id FROM workflow_runs WHERE idempotency_key = $1',
+        ['rollback-test-key'],
+      );
+      expect(remaining.rows).toHaveLength(0);
+    });
   });
 
   describe('pauseWorkflow(runId)', () => {
@@ -893,7 +947,9 @@ describe('WorkflowEngine', () => {
               },
             },
             'call-child-wait-for': {
-              waitFor: {},
+              waitFor: {
+                skipOutput: true,
+              },
             },
           },
         });
@@ -979,6 +1035,7 @@ describe('WorkflowEngine', () => {
               'call-child-wait-for': {
                 waitFor: {
                   eventName: `__invoke_workflow_completed:${childRun.id}`,
+                  skipOutput: true,
                 },
               },
             });
@@ -1144,6 +1201,110 @@ describe('WorkflowEngine', () => {
       }
     });
 
+    it('should look up an existing invoked child using its original resource id', async () => {
+      const now = new Date();
+      const parentRun: WorkflowRun = {
+        id: 'invoke-parent-child-resource-replay',
+        createdAt: now,
+        updatedAt: now,
+        resourceId,
+        workflowId: 'invoke-parent-child-resource-replay',
+        status: WorkflowStatus.RUNNING,
+        input: {},
+        output: null,
+        error: null,
+        currentStepId: 'call-child',
+        timeline: {},
+        pausedAt: null,
+        resumedAt: null,
+        completedAt: null,
+        timeoutAt: null,
+        retryCount: 0,
+        maxRetries: 0,
+        jobId: null,
+        idempotencyKey: null,
+        parentRunId: null,
+        parentStepId: null,
+        parentResourceId: null,
+      };
+      const childRun: WorkflowRun = {
+        id: 'invoke-child-resource-replay-run',
+        createdAt: now,
+        updatedAt: now,
+        resourceId: 'original-child-resource',
+        workflowId: 'invoke-child-resource-replay',
+        status: WorkflowStatus.COMPLETED,
+        input: {},
+        output: { ok: true },
+        error: null,
+        currentStepId: '',
+        timeline: {},
+        pausedAt: null,
+        resumedAt: null,
+        completedAt: now,
+        timeoutAt: null,
+        retryCount: 0,
+        maxRetries: 0,
+        jobId: null,
+        idempotencyKey: null,
+        parentRunId: parentRun.id,
+        parentStepId: 'call-child',
+        parentResourceId: resourceId,
+      };
+      const lockedParentRun: WorkflowRun = {
+        ...parentRun,
+        timeline: {
+          'call-child-invoke-workflow': {
+            invokeWorkflow: {
+              childRunId: childRun.id,
+              childWorkflowId: childRun.workflowId,
+              childResourceId: childRun.resourceId,
+            },
+            timestamp: now,
+          },
+        },
+      };
+      const engineWithInvokeWorkflowStep = engine as unknown as {
+        invokeWorkflowStep(args: {
+          run: WorkflowRun;
+          stepId: string;
+          workflowId: string;
+          input: unknown;
+          resourceId?: string;
+        }): Promise<unknown>;
+      };
+      let observedChildLookup = false;
+      const getRunSpy = vi.spyOn(engine, 'getRun').mockImplementation(async (params, options) => {
+        if (options?.exclusiveLock) {
+          return lockedParentRun;
+        }
+
+        expect(params).toEqual({
+          runId: childRun.id,
+          resourceId: childRun.resourceId,
+        });
+        observedChildLookup = true;
+        return childRun;
+      });
+      const updateRunSpy = vi.spyOn(engine, 'updateRun').mockResolvedValue(lockedParentRun);
+
+      try {
+        await expect(
+          engineWithInvokeWorkflowStep.invokeWorkflowStep({
+            run: parentRun,
+            stepId: 'call-child',
+            workflowId: childRun.workflowId,
+            input: {},
+            resourceId: 'changed-child-resource',
+          }),
+        ).resolves.toEqual({ ok: true });
+        expect(observedChildLookup).toBe(true);
+      } finally {
+        getRunSpy.mockRestore();
+        updateRunSpy.mockRestore();
+      }
+    });
+
     it('should fail instead of linking an explicit invoke idempotency key to an unrelated run', async () => {
       const childWorkflow = workflow('invoke-child-key-conflict', async ({ step }) => {
         await step.waitFor('child-wait', { eventName: 'child-ready' });
@@ -1286,6 +1447,8 @@ describe('WorkflowEngine', () => {
           status: WorkflowStatus.FAILED,
           error: expect.stringContaining('child exploded'),
         });
+      const failedParent = await engine.getRun({ runId: parentRun.id, resourceId });
+      expect(failedParent.timeline).not.toHaveProperty('call-child.output');
     });
 
     it('should fail the parent when an invoked child workflow is cancelled', async () => {
@@ -1328,9 +1491,11 @@ describe('WorkflowEngine', () => {
           status: WorkflowStatus.FAILED,
           error: expect.stringContaining('cancelled'),
         });
+      const failedParent = await engine.getRun({ runId: parentRun.id, resourceId });
+      expect(failedParent.timeline).not.toHaveProperty('call-child.output');
     });
 
-    it('should resume from cached child output even if fastForwardWorkflow is called after the child completes', async () => {
+    it('should ignore fastForwardWorkflow on invokeWorkflow waits and only resume via the real child completion', async () => {
       const childWorkflow = workflow('invoke-child-ff-after-complete', async ({ step }) => {
         await step.waitFor('child-wait', { eventName: 'child-ready' });
         return { ok: true };

--- a/src/engine.test.ts
+++ b/src/engine.test.ts
@@ -4,6 +4,7 @@ import * as v from 'valibot';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 import { WORKFLOW_RUN_DLQ_QUEUE_NAME, WORKFLOW_RUN_QUEUE_NAME } from './constants';
+import type { WorkflowRun } from './db/types';
 import { workflow } from './definition';
 import { WorkflowEngine } from './engine';
 import { WorkflowEngineError, WorkflowRunNotFoundError } from './error';
@@ -852,6 +853,674 @@ describe('WorkflowEngine', () => {
           async () => (await engine.getRun({ runId: run.id, resourceId: scopedResource })).status,
         )
         .toBe(WorkflowStatus.COMPLETED);
+    });
+
+    it('should invoke a child workflow and resume the parent with child output', async () => {
+      const childWorkflow = workflow('invoke-child-success', async ({ step }) => {
+        const event = await step.waitFor('child-wait', { eventName: 'child-ready' });
+        return { child: event };
+      });
+
+      const parentWorkflow = workflow('invoke-parent-success', async ({ step }) => {
+        const childOutput = await step.invokeWorkflow<{ child: { message: string } }>(
+          'call-child',
+          {
+            workflowId: 'invoke-child-success',
+            input: {},
+          },
+        );
+        return { childOutput };
+      });
+
+      await engine.registerWorkflow(childWorkflow);
+      await engine.registerWorkflow(parentWorkflow);
+
+      const parentRun = await engine.startWorkflow({
+        resourceId,
+        workflowId: 'invoke-parent-success',
+        input: {},
+      });
+
+      await expect
+        .poll(async () => await engine.getRun({ runId: parentRun.id, resourceId }))
+        .toMatchObject({
+          status: WorkflowStatus.PAUSED,
+          currentStepId: 'call-child',
+          timeline: {
+            'call-child-invoke-workflow': {
+              invokeWorkflow: {
+                childWorkflowId: 'invoke-child-success',
+              },
+            },
+            'call-child-wait-for': {
+              waitFor: {},
+            },
+          },
+        });
+
+      const childRuns = await engine.getRuns({ resourceId, workflowId: 'invoke-child-success' });
+      expect(childRuns.items).toHaveLength(1);
+      const childRun = childRuns.items[0];
+      expect(childRun.parentRunId).toBe(parentRun.id);
+      expect(childRun.parentStepId).toBe('call-child');
+      expect(childRun.parentResourceId).toBe(resourceId);
+      expect(childRun.idempotencyKey).toBeNull();
+
+      const sendSpy = vi.spyOn(testBoss, 'send');
+      try {
+        const resumeAttempt = await engine.resumeWorkflow({
+          runId: parentRun.id,
+          resourceId,
+        });
+        expect(resumeAttempt.status).toBe(WorkflowStatus.PAUSED);
+        expect(sendSpy).not.toHaveBeenCalled();
+      } finally {
+        sendSpy.mockRestore();
+      }
+
+      await engine.triggerEvent({
+        runId: childRun.id,
+        resourceId,
+        eventName: 'child-ready',
+        data: { message: 'done' },
+      });
+
+      await expect
+        .poll(async () => await engine.getRun({ runId: parentRun.id, resourceId }))
+        .toMatchObject({
+          status: WorkflowStatus.COMPLETED,
+          output: { childOutput: { child: { message: 'done' } } },
+          timeline: {
+            'call-child': {
+              output: { child: { message: 'done' } },
+            },
+          },
+        });
+    });
+
+    it('should enqueue child workflow only after parent invoke wait is committed', async () => {
+      const childWorkflow = workflow('invoke-child-post-commit', async ({ step }) => {
+        await step.waitFor('child-wait', { eventName: 'child-ready' });
+        return { ok: true };
+      });
+
+      const parentWorkflow = workflow('invoke-parent-post-commit', async ({ step }) => {
+        return await step.invokeWorkflow('call-child', {
+          workflowId: 'invoke-child-post-commit',
+          input: {},
+        });
+      });
+
+      await engine.registerWorkflow(childWorkflow);
+      await engine.registerWorkflow(parentWorkflow);
+
+      const originalSend = testBoss.send.bind(testBoss);
+      let observedCommittedParentWait = false;
+      const sendSpy = vi
+        .spyOn(testBoss, 'send')
+        .mockImplementation(async (queue, data, options) => {
+          const job = data as { runId?: string; workflowId?: string };
+          if (queue === WORKFLOW_RUN_QUEUE_NAME && job.workflowId === 'invoke-child-post-commit') {
+            const childRun = await engine.getRun({ runId: job.runId ?? '' });
+            expect(childRun.parentRunId).toBeTruthy();
+
+            const parentRun = await engine.getRun({
+              runId: childRun.parentRunId ?? '',
+              resourceId: childRun.parentResourceId ?? undefined,
+            });
+            expect(parentRun.status).toBe(WorkflowStatus.PAUSED);
+            expect(parentRun.timeline).toMatchObject({
+              'call-child-invoke-workflow': {
+                invokeWorkflow: {
+                  childRunId: childRun.id,
+                  childWorkflowId: 'invoke-child-post-commit',
+                },
+              },
+              'call-child-wait-for': {
+                waitFor: {
+                  eventName: `__invoke_workflow_completed:${childRun.id}`,
+                },
+              },
+            });
+            observedCommittedParentWait = true;
+          }
+
+          return await originalSend(queue, data, options);
+        });
+
+      try {
+        const parentRun = await engine.startWorkflow({
+          resourceId,
+          workflowId: 'invoke-parent-post-commit',
+          input: {},
+        });
+
+        await expect.poll(() => observedCommittedParentWait).toBe(true);
+        await expect
+          .poll(async () => (await engine.getRun({ runId: parentRun.id, resourceId })).status)
+          .toBe(WorkflowStatus.PAUSED);
+      } finally {
+        sendSpy.mockRestore();
+      }
+    });
+
+    it('should preserve null output from an invoked child workflow', async () => {
+      const childWorkflow = workflow('invoke-child-null-output', async ({ step }) => {
+        return await step.run('child-step', async () => null);
+      });
+
+      const parentWorkflow = workflow('invoke-parent-null-output', async ({ step }) => {
+        const childOutput = await step.invokeWorkflow<null>('call-child', {
+          workflowId: 'invoke-child-null-output',
+          input: {},
+        });
+        return { childOutput };
+      });
+
+      await engine.registerWorkflow(childWorkflow);
+      await engine.registerWorkflow(parentWorkflow);
+
+      const parentRun = await engine.startWorkflow({
+        resourceId,
+        workflowId: 'invoke-parent-null-output',
+        input: {},
+      });
+
+      await expect
+        .poll(async () => await engine.getRun({ runId: parentRun.id, resourceId }), {
+          timeout: 10_000,
+        })
+        .toMatchObject({
+          status: WorkflowStatus.COMPLETED,
+          output: { childOutput: null },
+          timeline: {
+            'call-child': {
+              output: null,
+            },
+          },
+        });
+    });
+
+    it('should not start duplicate child workflows when an invoke step replays', async () => {
+      const childWorkflow = workflow('invoke-child-idempotent', async ({ step }) => {
+        await step.waitFor('child-wait', { eventName: 'child-ready' });
+        return { ok: true };
+      });
+
+      const parentWorkflow = workflow('invoke-parent-idempotent', async ({ step }) => {
+        return await step.invokeWorkflow('call-child', {
+          workflowId: 'invoke-child-idempotent',
+          input: {},
+        });
+      });
+
+      await engine.registerWorkflow(childWorkflow);
+      await engine.registerWorkflow(parentWorkflow);
+
+      const parentRun = await engine.startWorkflow({
+        resourceId,
+        workflowId: 'invoke-parent-idempotent',
+        input: {},
+      });
+
+      await expect
+        .poll(async () => (await engine.getRun({ runId: parentRun.id, resourceId })).status)
+        .toBe(WorkflowStatus.PAUSED);
+
+      await testBoss.send(WORKFLOW_RUN_QUEUE_NAME, {
+        runId: parentRun.id,
+        resourceId,
+        workflowId: 'invoke-parent-idempotent',
+        input: {},
+      });
+
+      await expect
+        .poll(async () => (await engine.getRun({ runId: parentRun.id, resourceId })).status)
+        .toBe(WorkflowStatus.PAUSED);
+
+      const childRuns = await engine.getRuns({ resourceId, workflowId: 'invoke-child-idempotent' });
+      expect(childRuns.items).toHaveLength(1);
+      expect(childRuns.items[0].idempotencyKey).toBeNull();
+    });
+
+    it('should return invokeWorkflow output cached after acquiring the parent lock', async () => {
+      const now = new Date();
+      const parentRun: WorkflowRun = {
+        id: 'invoke-parent-lock-race',
+        createdAt: now,
+        updatedAt: now,
+        resourceId,
+        workflowId: 'invoke-parent-lock-race',
+        status: WorkflowStatus.RUNNING,
+        input: {},
+        output: null,
+        error: null,
+        currentStepId: 'call-child',
+        timeline: {},
+        pausedAt: null,
+        resumedAt: null,
+        completedAt: null,
+        timeoutAt: null,
+        retryCount: 0,
+        maxRetries: 0,
+        jobId: null,
+        idempotencyKey: null,
+        parentRunId: null,
+        parentStepId: null,
+        parentResourceId: null,
+      };
+      const lockedParentRun: WorkflowRun = {
+        ...parentRun,
+        timeline: {
+          'call-child': {
+            output: { ok: true },
+            timestamp: now,
+          },
+        },
+      };
+      const engineWithInvokeWorkflowStep = engine as unknown as {
+        invokeWorkflowStep(args: {
+          run: WorkflowRun;
+          stepId: string;
+          workflowId: string;
+          input: unknown;
+        }): Promise<unknown>;
+      };
+      const getRunSpy = vi.spyOn(engine, 'getRun').mockImplementation(async (_params, options) => {
+        return options?.exclusiveLock ? lockedParentRun : parentRun;
+      });
+
+      try {
+        await expect(
+          engineWithInvokeWorkflowStep.invokeWorkflowStep({
+            run: parentRun,
+            stepId: 'call-child',
+            workflowId: 'invoke-child-lock-race',
+            input: {},
+          }),
+        ).resolves.toEqual({ ok: true });
+      } finally {
+        getRunSpy.mockRestore();
+      }
+    });
+
+    it('should fail instead of linking an explicit invoke idempotency key to an unrelated run', async () => {
+      const childWorkflow = workflow('invoke-child-key-conflict', async ({ step }) => {
+        await step.waitFor('child-wait', { eventName: 'child-ready' });
+        return { ok: true };
+      });
+
+      const parentWorkflow = workflow('invoke-parent-key-conflict', async ({ step }) => {
+        await step.invokeWorkflow('call-child', {
+          workflowId: 'invoke-child-key-conflict',
+          input: {},
+          idempotencyKey: 'invoke-child-conflict-key',
+        });
+        return { unreachable: true };
+      });
+
+      await engine.registerWorkflow(childWorkflow);
+      await engine.registerWorkflow(parentWorkflow);
+
+      const unrelatedChild = await engine.startWorkflow({
+        resourceId,
+        workflowId: 'invoke-child-key-conflict',
+        input: {},
+        idempotencyKey: 'invoke-child-conflict-key',
+      });
+
+      await expect
+        .poll(async () => (await engine.getRun({ runId: unrelatedChild.id, resourceId })).status)
+        .toBe(WorkflowStatus.PAUSED);
+
+      const parentRun = await engine.startWorkflow({
+        resourceId,
+        workflowId: 'invoke-parent-key-conflict',
+        input: {},
+      });
+
+      await expect
+        .poll(async () => await engine.getRun({ runId: parentRun.id, resourceId }), {
+          timeout: 10_000,
+        })
+        .toMatchObject({
+          status: WorkflowStatus.FAILED,
+          error: expect.stringContaining('does not belong to invokeWorkflow step'),
+        });
+    });
+
+    it('should retry cleanly when child enqueue fails after parent pause is prepared', async () => {
+      const childWorkflow = workflow('invoke-child-enqueue-retry', async ({ step }) => {
+        return await step.run('child-step', async () => ({ ok: true }));
+      });
+
+      const parentWorkflow = workflow('invoke-parent-enqueue-retry', async ({ step }) => {
+        return await step.invokeWorkflow('call-child', {
+          workflowId: 'invoke-child-enqueue-retry',
+          input: {},
+        });
+      });
+
+      await engine.registerWorkflow(childWorkflow);
+      await engine.registerWorkflow(parentWorkflow);
+
+      const originalSend = testBoss.send.bind(testBoss);
+      let rejectedChildEnqueue = false;
+      let childEnqueueAttempts = 0;
+      const sendSpy = vi
+        .spyOn(testBoss, 'send')
+        .mockImplementation(async (queue, data, options) => {
+          const job = data as { workflowId?: string };
+          if (
+            queue === WORKFLOW_RUN_QUEUE_NAME &&
+            job.workflowId === 'invoke-child-enqueue-retry'
+          ) {
+            childEnqueueAttempts++;
+            if (!rejectedChildEnqueue) {
+              rejectedChildEnqueue = true;
+              throw new Error('simulated child enqueue failure');
+            }
+          }
+
+          return await originalSend(queue, data, options);
+        });
+
+      try {
+        const parentRun = await engine.startWorkflow({
+          resourceId,
+          workflowId: 'invoke-parent-enqueue-retry',
+          input: {},
+          options: { retries: 1 },
+        });
+
+        await expect
+          .poll(async () => await engine.getRun({ runId: parentRun.id, resourceId }), {
+            timeout: 15_000,
+          })
+          .toMatchObject({
+            status: WorkflowStatus.COMPLETED,
+            output: { ok: true },
+          });
+
+        expect(rejectedChildEnqueue).toBe(true);
+        expect(childEnqueueAttempts).toBe(2);
+        const childRuns = await engine.getRuns({
+          resourceId,
+          workflowId: 'invoke-child-enqueue-retry',
+        });
+        expect(childRuns.items).toHaveLength(1);
+      } finally {
+        sendSpy.mockRestore();
+      }
+    });
+
+    it('should fail the parent when an invoked child workflow fails', async () => {
+      const childWorkflow = workflow('invoke-child-fails', async ({ step }) => {
+        await step.run('fail', async () => {
+          throw new Error('child exploded');
+        });
+      });
+
+      const parentWorkflow = workflow('invoke-parent-child-fails', async ({ step }) => {
+        await step.invokeWorkflow('call-child', {
+          workflowId: 'invoke-child-fails',
+          input: {},
+        });
+        return { unreachable: true };
+      });
+
+      await engine.registerWorkflow(childWorkflow);
+      await engine.registerWorkflow(parentWorkflow);
+
+      const parentRun = await engine.startWorkflow({
+        resourceId,
+        workflowId: 'invoke-parent-child-fails',
+        input: {},
+      });
+
+      await expect
+        .poll(async () => await engine.getRun({ runId: parentRun.id, resourceId }), {
+          timeout: 10000,
+        })
+        .toMatchObject({
+          status: WorkflowStatus.FAILED,
+          error: expect.stringContaining('child exploded'),
+        });
+    });
+
+    it('should fail the parent when an invoked child workflow is cancelled', async () => {
+      const childWorkflow = workflow('invoke-child-cancelled', async ({ step }) => {
+        await step.waitFor('child-wait', { eventName: 'child-ready' });
+        return { ok: true };
+      });
+
+      const parentWorkflow = workflow('invoke-parent-child-cancelled', async ({ step }) => {
+        await step.invokeWorkflow('call-child', {
+          workflowId: 'invoke-child-cancelled',
+          input: {},
+        });
+        return { unreachable: true };
+      });
+
+      await engine.registerWorkflow(childWorkflow);
+      await engine.registerWorkflow(parentWorkflow);
+
+      const parentRun = await engine.startWorkflow({
+        resourceId,
+        workflowId: 'invoke-parent-child-cancelled',
+        input: {},
+      });
+
+      await expect
+        .poll(async () => (await engine.getRun({ runId: parentRun.id, resourceId })).status)
+        .toBe(WorkflowStatus.PAUSED);
+
+      const childRuns = await engine.getRuns({ resourceId, workflowId: 'invoke-child-cancelled' });
+      expect(childRuns.items).toHaveLength(1);
+
+      await engine.cancelWorkflow({ runId: childRuns.items[0].id, resourceId });
+
+      await expect
+        .poll(async () => await engine.getRun({ runId: parentRun.id, resourceId }), {
+          timeout: 10000,
+        })
+        .toMatchObject({
+          status: WorkflowStatus.FAILED,
+          error: expect.stringContaining('cancelled'),
+        });
+    });
+
+    it('should resume from cached child output even if fastForwardWorkflow is called after the child completes', async () => {
+      const childWorkflow = workflow('invoke-child-ff-after-complete', async ({ step }) => {
+        await step.waitFor('child-wait', { eventName: 'child-ready' });
+        return { ok: true };
+      });
+
+      const parentWorkflow = workflow('invoke-parent-ff-after-complete', async ({ step }) => {
+        return await step.invokeWorkflow('call-child', {
+          workflowId: 'invoke-child-ff-after-complete',
+          input: {},
+        });
+      });
+
+      await engine.registerWorkflow(childWorkflow);
+      await engine.registerWorkflow(parentWorkflow);
+
+      const parentRun = await engine.startWorkflow({
+        resourceId,
+        workflowId: 'invoke-parent-ff-after-complete',
+        input: {},
+      });
+
+      await expect
+        .poll(async () => (await engine.getRun({ runId: parentRun.id, resourceId })).status)
+        .toBe(WorkflowStatus.PAUSED);
+
+      const childRuns = await engine.getRuns({
+        resourceId,
+        workflowId: 'invoke-child-ff-after-complete',
+      });
+      expect(childRuns.items).toHaveLength(1);
+      const childRun = childRuns.items[0];
+
+      // Calling fastForwardWorkflow on an invokeWorkflow wait must always be a
+      // no-op; only the real invoke-completion event drives the parent forward.
+      const ffWhilePending = await engine.fastForwardWorkflow({
+        runId: parentRun.id,
+        resourceId,
+        data: { fake: true },
+      });
+      expect(ffWhilePending.status).toBe(WorkflowStatus.PAUSED);
+
+      await engine.triggerEvent({
+        runId: childRun.id,
+        resourceId,
+        eventName: 'child-ready',
+      });
+
+      await expect
+        .poll(async () => await engine.getRun({ runId: parentRun.id, resourceId }), {
+          timeout: 10_000,
+        })
+        .toMatchObject({
+          status: WorkflowStatus.COMPLETED,
+          output: { ok: true },
+        });
+    });
+
+    it('should fail the parent when its timeout fires while the child is still running', async () => {
+      const childWorkflow = workflow('invoke-child-parent-timeout', async ({ step }) => {
+        await step.waitFor('child-wait', { eventName: 'child-ready' });
+        return { ok: true };
+      });
+
+      const parentWorkflow = workflow('invoke-parent-parent-timeout', async ({ step }) => {
+        return await step.invokeWorkflow('call-child', {
+          workflowId: 'invoke-child-parent-timeout',
+          input: {},
+        });
+      });
+
+      await engine.registerWorkflow(childWorkflow);
+      await engine.registerWorkflow(parentWorkflow);
+
+      const parentRun = await engine.startWorkflow({
+        resourceId,
+        workflowId: 'invoke-parent-parent-timeout',
+        input: {},
+        // Short parent timeout so the parent times out while the child is
+        // still waiting for `child-ready`.
+        options: { timeout: 200 },
+      });
+
+      await expect
+        .poll(async () => (await engine.getRun({ runId: parentRun.id, resourceId })).status)
+        .toBe(WorkflowStatus.PAUSED);
+
+      // Simulate the parent timeout firing: cancel the parent, which is the
+      // engine's terminal "give up" path. Children are intentionally not
+      // cancelled (documented behaviour) - the child should remain in PAUSED
+      // and the parent's wakeup event should be dropped.
+      await engine.cancelWorkflow({ runId: parentRun.id, resourceId });
+
+      const parentAfterCancel = await engine.getRun({ runId: parentRun.id, resourceId });
+      expect(parentAfterCancel.status).toBe(WorkflowStatus.CANCELLED);
+
+      const childRuns = await engine.getRuns({
+        resourceId,
+        workflowId: 'invoke-child-parent-timeout',
+      });
+      expect(childRuns.items).toHaveLength(1);
+      const childBefore = childRuns.items[0];
+      expect(childBefore.status).toBe(WorkflowStatus.PAUSED);
+
+      // Completing the child must NOT revive the parent.
+      await engine.triggerEvent({
+        runId: childBefore.id,
+        resourceId,
+        eventName: 'child-ready',
+      });
+
+      await expect
+        .poll(async () => (await engine.getRun({ runId: childBefore.id, resourceId })).status, {
+          timeout: 10_000,
+        })
+        .toBe(WorkflowStatus.COMPLETED);
+
+      const parentFinal = await engine.getRun({ runId: parentRun.id, resourceId });
+      expect(parentFinal.status).toBe(WorkflowStatus.CANCELLED);
+    });
+
+    it('should ignore a duplicate invoke-completion event after the parent has completed', async () => {
+      const childWorkflow = workflow('invoke-child-duplicate-wakeup', async ({ step }) => {
+        await step.waitFor('child-wait', { eventName: 'child-ready' });
+        return { value: 'done' };
+      });
+
+      const parentWorkflow = workflow('invoke-parent-duplicate-wakeup', async ({ step }) => {
+        const childOutput = await step.invokeWorkflow<{ value: string }>('call-child', {
+          workflowId: 'invoke-child-duplicate-wakeup',
+          input: {},
+        });
+        return { childOutput };
+      });
+
+      await engine.registerWorkflow(childWorkflow);
+      await engine.registerWorkflow(parentWorkflow);
+
+      const parentRun = await engine.startWorkflow({
+        resourceId,
+        workflowId: 'invoke-parent-duplicate-wakeup',
+        input: {},
+      });
+
+      await expect
+        .poll(async () => (await engine.getRun({ runId: parentRun.id, resourceId })).status)
+        .toBe(WorkflowStatus.PAUSED);
+
+      const childRuns = await engine.getRuns({
+        resourceId,
+        workflowId: 'invoke-child-duplicate-wakeup',
+      });
+      expect(childRuns.items).toHaveLength(1);
+      const childRun = childRuns.items[0];
+
+      // First, let the child complete via the engine's own notify path so the
+      // parent ends up COMPLETED with the real child output.
+      await engine.triggerEvent({
+        runId: childRun.id,
+        resourceId,
+        eventName: 'child-ready',
+      });
+
+      await expect
+        .poll(async () => await engine.getRun({ runId: parentRun.id, resourceId }), {
+          timeout: 10_000,
+        })
+        .toMatchObject({
+          status: WorkflowStatus.COMPLETED,
+          output: { childOutput: { value: 'done' } },
+        });
+
+      // Now redeliver the same wakeup with a different payload. The parent is
+      // already terminal, so the worker must see status !== PAUSED, skip the
+      // wait-for unlock branch, fall through to the (now no-op) handler path,
+      // and never overwrite the cached output. This guards the
+      // "child notify fires twice (catch + DLQ)" deduplication path.
+      const eventName = `__invoke_workflow_completed:${childRun.id}`;
+      await testBoss.send(WORKFLOW_RUN_QUEUE_NAME, {
+        runId: parentRun.id,
+        resourceId,
+        workflowId: 'invoke-parent-duplicate-wakeup',
+        input: {},
+        event: { name: eventName, data: { value: 'should-be-ignored' } },
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+
+      const finalParent = await engine.getRun({ runId: parentRun.id, resourceId });
+      expect(finalParent.status).toBe(WorkflowStatus.COMPLETED);
+      expect(finalParent.output).toEqual({ childOutput: { value: 'done' } });
     });
 
     it('should handle workflow with pause step', async () => {
@@ -2203,6 +2872,63 @@ describe('WorkflowEngine', () => {
         .toMatchObject({
           status: WorkflowStatus.COMPLETED,
           output: 'done',
+        });
+    });
+
+    it('should not fast-forward an invokeWorkflow step while the child is still running', async () => {
+      const childWorkflow = workflow('ff-method-invoke-child', async ({ step }) => {
+        await step.waitFor('child-wait', { eventName: 'child-ready' });
+        return { ok: true };
+      });
+
+      const parentWorkflow = workflow('ff-method-invoke-parent', async ({ step }) => {
+        return await step.invokeWorkflow('call-child', {
+          workflowId: 'ff-method-invoke-child',
+          input: {},
+        });
+      });
+
+      await engine.registerWorkflow(childWorkflow);
+      await engine.registerWorkflow(parentWorkflow);
+
+      const parentRun = await engine.startWorkflow({
+        resourceId,
+        workflowId: 'ff-method-invoke-parent',
+        input: {},
+      });
+
+      await expect
+        .poll(async () => (await engine.getRun({ runId: parentRun.id, resourceId })).status, {
+          timeout: 10_000,
+        })
+        .toBe(WorkflowStatus.PAUSED);
+
+      await engine.fastForwardWorkflow({
+        runId: parentRun.id,
+        resourceId,
+        data: { fake: true },
+      });
+
+      const stillPaused = await engine.getRun({ runId: parentRun.id, resourceId });
+      expect(stillPaused.status).toBe(WorkflowStatus.PAUSED);
+      expect(stillPaused.timeline).not.toHaveProperty('call-child.output');
+
+      const childRuns = await engine.getRuns({ resourceId, workflowId: 'ff-method-invoke-child' });
+      expect(childRuns.items).toHaveLength(1);
+
+      await engine.triggerEvent({
+        runId: childRuns.items[0].id,
+        resourceId,
+        eventName: 'child-ready',
+      });
+
+      await expect
+        .poll(async () => await engine.getRun({ runId: parentRun.id, resourceId }), {
+          timeout: 10_000,
+        })
+        .toMatchObject({
+          status: WorkflowStatus.COMPLETED,
+          output: { ok: true },
         });
     });
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -4,8 +4,8 @@ import { type Db, type JobWithMetadata, PgBoss } from 'pg-boss';
 import { parseWorkflowHandler } from './ast-parser';
 import {
   DEFAULT_PGBOSS_SCHEMA,
-  invokeWorkflowTimelineKey,
-  isInvokeWorkflowTimelineEntry,
+  invokeChildWorkflowTimelineKey,
+  isInvokeChildWorkflowTimelineEntry,
   PAUSE_EVENT_NAME,
   WORKFLOW_RUN_DLQ_QUEUE_NAME,
   WORKFLOW_RUN_QUEUE_NAME,
@@ -71,7 +71,7 @@ const StepTypeToIcon = {
   [StepType.WAIT_UNTIL]: '⏲',
   [StepType.DELAY]: '⏱',
   [StepType.POLL]: '↻',
-  [StepType.INVOKE_WORKFLOW]: '↪',
+  [StepType.INVOKE_CHILD_WORKFLOW]: '↪',
 };
 
 // Timeline entry types
@@ -90,8 +90,8 @@ type TimelineWaitForEntry = {
   timestamp: Date;
 };
 
-type TimelineInvokeWorkflowEntry = {
-  invokeWorkflow: {
+type TimelineInvokeChildWorkflowEntry = {
+  invokeChildWorkflow: {
     childRunId: string;
     childWorkflowId: string;
     childResourceId?: string | null;
@@ -128,8 +128,8 @@ const retrySendOptions = (maxRetries: number) => ({
   retryDelay: 1,
 });
 
-const getInvokeWorkflowEventName = (childRunId: string) =>
-  `__invoke_workflow_completed:${childRunId}`;
+const getInvokeChildWorkflowEventName = (childRunId: string) =>
+  `__invoke_child_workflow_completed:${childRunId}`;
 
 // pg-boss workers auto-touch heartbeat_on every heartbeatSeconds / 2 seconds
 // while the process is alive. If the worker dies, heartbeats stop and pg-boss's
@@ -543,7 +543,7 @@ export class WorkflowEngine {
     await this.triggerEvent({
       runId: parentRun.id,
       resourceId: parentRun.resourceId ?? undefined,
-      eventName: getInvokeWorkflowEventName(childRun.id),
+      eventName: getInvokeChildWorkflowEventName(childRun.id),
     });
   }
 
@@ -595,7 +595,7 @@ export class WorkflowEngine {
       );
     }
 
-    if (this.getInvokeWorkflowStepEntry(current.timeline, current.currentStepId)) {
+    if (this.getInvokeChildWorkflowStepEntry(current.timeline, current.currentStepId)) {
       return current;
     }
 
@@ -626,7 +626,7 @@ export class WorkflowEngine {
     }
 
     const stepId = run.currentStepId;
-    if (this.getInvokeWorkflowStepEntry(run.timeline, stepId)) {
+    if (this.getInvokeChildWorkflowStepEntry(run.timeline, stepId)) {
       return run;
     }
 
@@ -1089,7 +1089,7 @@ export class WorkflowEngine {
             { timedOut: false; data: T } | { timedOut: true }
           >;
         },
-        invokeWorkflow: async <TInput extends InputParameters, TOutput = unknown>(
+        invokeChildWorkflow: async <TInput extends InputParameters, TOutput = unknown>(
           stepId: string,
           refOrParams:
             | WorkflowRef<TInput, TOutput>
@@ -1107,16 +1107,23 @@ export class WorkflowEngine {
             throw new WorkflowEngineError('Missing workflow run', workflowId, runId);
           }
 
-          const params = this.resolveWorkflowRunParameters(refOrParams, inputArg, optionsArg);
-          return this.invokeWorkflowStep({
+          // Resolve overload input (typed ref or params object) into one shape
+          // before handing off to the durable child-invocation implementation.
+          const resolvedChildCall = this.resolveWorkflowRunParameters(
+            refOrParams,
+            inputArg,
+            optionsArg,
+          );
+          const childWorkflowInvocation = {
             run,
             stepId,
-            workflowId: params.workflowId,
-            input: params.input,
-            options: params.options,
-            resourceId: params.resourceId,
-            idempotencyKey: params.idempotencyKey,
-          }) as Promise<TOutput>;
+            workflowId: resolvedChildCall.workflowId,
+            input: resolvedChildCall.input,
+            options: resolvedChildCall.options,
+            resourceId: resolvedChildCall.resourceId,
+            idempotencyKey: resolvedChildCall.idempotencyKey,
+          };
+          return this.invokeChildWorkflowStep(childWorkflowInvocation) as Promise<TOutput>;
         },
       };
 
@@ -1241,12 +1248,14 @@ export class WorkflowEngine {
       : null;
   }
 
-  private getInvokeWorkflowStepEntry(
+  private getInvokeChildWorkflowStepEntry(
     timeline: Record<string, unknown>,
     stepId: string,
-  ): TimelineInvokeWorkflowEntry | null {
-    const entry = timeline[invokeWorkflowTimelineKey(stepId)];
-    return isInvokeWorkflowTimelineEntry(entry) ? (entry as TimelineInvokeWorkflowEntry) : null;
+  ): TimelineInvokeChildWorkflowEntry | null {
+    const entry = timeline[invokeChildWorkflowTimelineKey(stepId)];
+    return isInvokeChildWorkflowTimelineEntry(entry)
+      ? (entry as TimelineInvokeChildWorkflowEntry)
+      : null;
   }
 
   /**
@@ -1273,7 +1282,7 @@ export class WorkflowEngine {
     );
   }
 
-  private assertInvokeWorkflowChildMatches({
+  private assertInvokeChildWorkflowStepOwnership({
     childRun,
     parentRun,
     stepId,
@@ -1293,7 +1302,7 @@ export class WorkflowEngine {
 
     if (!matches) {
       throw new WorkflowEngineError(
-        `Idempotency key resolved to workflow run ${childRun.id}, which does not belong to invokeWorkflow step '${stepId}'`,
+        `Idempotency key resolved to workflow run ${childRun.id}, which does not belong to invokeChildWorkflow step '${stepId}'`,
         workflowId,
         parentRun.id,
       );
@@ -1311,7 +1320,7 @@ export class WorkflowEngine {
   // post-commit + revert-on-failure pattern used by waitStep/pollStep; the
   // re-send semantics are still safe because the existingInvoke branch detects
   // the already-created child on retry and re-pauses without re-creating it.
-  private async invokeWorkflowStep({
+  private async invokeChildWorkflowStep({
     run,
     stepId,
     workflowId,
@@ -1359,14 +1368,14 @@ export class WorkflowEngine {
           return;
         }
 
-        const lockedInvoke = this.getInvokeWorkflowStepEntry(lockedRun.timeline, stepId);
+        const lockedInvoke = this.getInvokeChildWorkflowStepEntry(lockedRun.timeline, stepId);
         if (lockedInvoke) {
           const existingChildResourceId =
-            'childResourceId' in lockedInvoke.invokeWorkflow
-              ? (lockedInvoke.invokeWorkflow.childResourceId ?? undefined)
+            'childResourceId' in lockedInvoke.invokeChildWorkflow
+              ? (lockedInvoke.invokeChildWorkflow.childResourceId ?? undefined)
               : childResourceId;
           const existingChildRun = await this.getRun({
-            runId: lockedInvoke.invokeWorkflow.childRunId,
+            runId: lockedInvoke.invokeChildWorkflow.childRunId,
             resourceId: existingChildResourceId,
           });
           if (existingChildRun.status === WorkflowStatus.COMPLETED) {
@@ -1402,7 +1411,7 @@ export class WorkflowEngine {
           await this.pauseRunForWait({
             run: lockedRun,
             stepId,
-            eventName: getInvokeWorkflowEventName(existingChildRun.id),
+            eventName: getInvokeChildWorkflowEventName(existingChildRun.id),
             skipOutput: true,
             db,
           });
@@ -1425,7 +1434,7 @@ export class WorkflowEngine {
         const childRun = result.run;
 
         if (!result.created) {
-          this.assertInvokeWorkflowChildMatches({
+          this.assertInvokeChildWorkflowStepOwnership({
             childRun,
             parentRun: lockedRun,
             stepId,
@@ -1441,8 +1450,8 @@ export class WorkflowEngine {
                 resourceId: run.resourceId ?? undefined,
                 data: {
                   timeline: merge(lockedRun.timeline, {
-                    [invokeWorkflowTimelineKey(stepId)]: {
-                      invokeWorkflow: {
+                    [invokeChildWorkflowTimelineKey(stepId)]: {
+                      invokeChildWorkflow: {
                         childRunId: childRun.id,
                         childWorkflowId: childRun.workflowId,
                         childResourceId: childRun.resourceId,
@@ -1475,12 +1484,12 @@ export class WorkflowEngine {
         await this.pauseRunForWait({
           run: lockedRun,
           stepId,
-          eventName: getInvokeWorkflowEventName(childRun.id),
+          eventName: getInvokeChildWorkflowEventName(childRun.id),
           skipOutput: true,
           db,
           timeline: merge(lockedRun.timeline, {
-            [invokeWorkflowTimelineKey(stepId)]: {
-              invokeWorkflow: {
+            [invokeChildWorkflowTimelineKey(stepId)]: {
+              invokeChildWorkflow: {
                 childRunId: childRun.id,
                 childWorkflowId: childRun.workflowId,
                 childResourceId: childRun.resourceId,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -36,19 +36,15 @@ import {
   type WorkflowInternalLoggerContext,
   type WorkflowLogger,
   type WorkflowRef,
+  type WorkflowRunOptions,
   type WorkflowRunProgress,
   WorkflowStatus,
 } from './types';
 
 const LOG_PREFIX = '[WorkflowEngine]';
 
-type StartWorkflowOptions = {
-  resourceId?: string;
-  timeout?: number;
-  retries?: number;
-  expireInSeconds?: number;
+type StartWorkflowOptions = WorkflowRunOptions & {
   batchSize?: number;
-  idempotencyKey?: string;
 };
 
 export type WorkflowEngineOptions = {
@@ -64,6 +60,7 @@ const StepTypeToIcon = {
   [StepType.WAIT_UNTIL]: '⏲',
   [StepType.DELAY]: '⏱',
   [StepType.POLL]: '↻',
+  [StepType.INVOKE_WORKFLOW]: '↪',
 };
 
 // Timeline entry types
@@ -82,6 +79,22 @@ type TimelineWaitForEntry = {
   timestamp: Date;
 };
 
+type TimelineInvokeWorkflowEntry = {
+  invokeWorkflow: {
+    childRunId: string;
+    childWorkflowId: string;
+  };
+  timestamp: Date;
+};
+
+type InvokeWorkflowFailureOutput = {
+  __pgWorkflowsInvokeWorkflowError: true;
+  childRunId: string;
+  childWorkflowId: string;
+  status: WorkflowStatus.FAILED | WorkflowStatus.CANCELLED;
+  error?: string;
+};
+
 type WorkflowRunJobParameters = {
   runId: string;
   resourceId?: string;
@@ -89,7 +102,7 @@ type WorkflowRunJobParameters = {
   input: unknown;
   event?: {
     name: string;
-    data?: Record<string, unknown>;
+    data?: unknown;
   };
 };
 
@@ -110,6 +123,9 @@ const retrySendOptions = (maxRetries: number) => ({
   retryBackoff: true,
   retryDelay: 1,
 });
+
+const getInvokeWorkflowEventName = (childRunId: string) =>
+  `__invoke_workflow_completed:${childRunId}`;
 
 // pg-boss workers auto-touch heartbeat_on every heartbeatSeconds / 2 seconds
 // while the process is alive. If the worker dies, heartbeats stop and pg-boss's
@@ -340,12 +356,51 @@ export class WorkflowEngine {
       options = params.options;
     }
 
-    validateWorkflowId(workflowId);
-    validateResourceId(resourceId);
-
     if (!this._started) {
       await this.start(false, { batchSize: options?.batchSize ?? 1 });
     }
+
+    const { run } = await this.createWorkflowRun({
+      workflowId,
+      input,
+      resourceId,
+      idempotencyKey,
+      options,
+    });
+
+    this.logger.log('Started workflow run', {
+      runId: run.id,
+      workflowId,
+    });
+
+    return run;
+  }
+
+  private async createWorkflowRun({
+    workflowId,
+    input,
+    resourceId,
+    idempotencyKey,
+    options,
+    parentRunId,
+    parentStepId,
+    parentResourceId,
+    enqueue = true,
+    db,
+  }: {
+    workflowId: string;
+    input: unknown;
+    resourceId?: string;
+    idempotencyKey?: string;
+    options?: WorkflowRunOptions;
+    parentRunId?: string;
+    parentStepId?: string;
+    parentResourceId?: string;
+    enqueue?: boolean;
+    db?: Db;
+  }): Promise<{ run: WorkflowRun; created: boolean }> {
+    validateWorkflowId(workflowId);
+    validateResourceId(resourceId);
 
     const workflow = this.workflows.get(workflowId);
     if (!workflow) {
@@ -371,56 +426,103 @@ export class WorkflowEngine {
     }
 
     const initialStepId = workflow.steps[0]?.id ?? '__start__';
+    const timeoutAt = options?.timeout
+      ? new Date(Date.now() + options.timeout)
+      : workflow.timeout
+        ? new Date(Date.now() + workflow.timeout)
+        : null;
 
-    const run = await withPostgresTransaction(
-      this.boss.getDb(),
-      async (_db) => {
-        const timeoutAt = options?.timeout
-          ? new Date(Date.now() + options.timeout)
-          : workflow.timeout
-            ? new Date(Date.now() + workflow.timeout)
-            : null;
-
-        const { run: insertedRun, created } = await insertWorkflowRun(
-          {
-            resourceId,
-            workflowId,
-            currentStepId: initialStepId,
-            status: WorkflowStatus.RUNNING,
-            input,
-            maxRetries: options?.retries ?? workflow.retries ?? 0,
-            timeoutAt,
-            idempotencyKey,
-          },
-          _db,
-        );
-
-        if (created) {
-          const job: WorkflowRunJobParameters = {
-            runId: insertedRun.id,
-            resourceId,
-            workflowId,
-            input,
-          };
-
-          await this.boss.send(WORKFLOW_RUN_QUEUE_NAME, job, {
-            startAfter: new Date(),
-            expireInSeconds: options?.expireInSeconds ?? defaultExpireInSeconds,
-            ...retrySendOptions(insertedRun.maxRetries),
-          });
-        }
-
-        return insertedRun;
+    const insertRun = async (targetDb: Db) => await insertWorkflowRun({
+        resourceId,
+        workflowId,
+        currentStepId: initialStepId,
+        status: WorkflowStatus.RUNNING,
+        input,
+        maxRetries: options?.retries ?? workflow.retries ?? 0,
+        timeoutAt,
+        idempotencyKey,
+        parentRunId,
+        parentStepId,
+        parentResourceId,
       },
-      this.pool,
+      targetDb,
     );
 
-    this.logger.log('Started workflow run', {
-      runId: run.id,
-      workflowId,
-    });
+    const { run, created } = db
+      ? await insertRun(db)
+      : await withPostgresTransaction(
+          this.boss.getDb(),
+          async (transactionDb) => {
+            const result = await insertRun(transactionDb);
+            if (enqueue && result.created) {
+              await this.enqueueWorkflowRun(result.run, options);
+            }
+            return result;
+          },
+          this.pool,
+        );
 
-    return run;
+    if (db && enqueue && created) {
+      await this.enqueueWorkflowRun(run, options);
+    }
+
+    return { run, created };
+  }
+
+  private async enqueueWorkflowRun(
+    run: WorkflowRun,
+    options?: { expireInSeconds?: number },
+  ) {
+    const job: WorkflowRunJobParameters = {
+      runId: run.id,
+      resourceId: run.resourceId ?? undefined,
+      workflowId: run.workflowId,
+      input: run.input,
+    };
+
+    await this.boss.send(WORKFLOW_RUN_QUEUE_NAME, job, {
+      startAfter: new Date(),
+      expireInSeconds: options?.expireInSeconds ?? defaultExpireInSeconds,
+      ...retrySendOptions(run.maxRetries),
+    });
+  }
+
+  private async notifyParentOfChildTerminalRun(childRun: WorkflowRun) {
+    if (!childRun.parentRunId || !childRun.parentStepId) {
+      return;
+    }
+
+    const parentRun = await getWorkflowRun(
+      {
+        runId: childRun.parentRunId,
+        resourceId: childRun.parentResourceId ?? undefined,
+      },
+      { db: this.db },
+    );
+    if (
+      !parentRun ||
+      parentRun.status === WorkflowStatus.COMPLETED ||
+      parentRun.status === WorkflowStatus.FAILED ||
+      parentRun.status === WorkflowStatus.CANCELLED
+    ) {
+      return;
+    }
+
+    const job: WorkflowRunJobParameters = {
+      runId: parentRun.id,
+      resourceId: parentRun.resourceId ?? undefined,
+      workflowId: parentRun.workflowId,
+      input: parentRun.input,
+      event: {
+        name: getInvokeWorkflowEventName(childRun.id),
+        data: this.getInvokeWorkflowTerminalOutput(childRun),
+      },
+    };
+
+    await this.boss.send(WORKFLOW_RUN_QUEUE_NAME, job, {
+      expireInSeconds: defaultExpireInSeconds,
+      ...retrySendOptions(parentRun.maxRetries),
+    });
   }
 
   async pauseWorkflow({
@@ -471,6 +573,10 @@ export class WorkflowEngine {
       );
     }
 
+    if (this.getInvokeWorkflowStepEntry(current.timeline, current.currentStepId)) {
+      return current;
+    }
+
     return this.triggerEvent({
       runId,
       resourceId,
@@ -498,6 +604,10 @@ export class WorkflowEngine {
     }
 
     const stepId = run.currentStepId;
+    if (this.getInvokeWorkflowStepEntry(run.timeline, stepId)) {
+      return run;
+    }
+
     const waitForStep = this.getWaitForStepEntry(run.timeline, stepId);
 
     if (!waitForStep) {
@@ -571,6 +681,8 @@ export class WorkflowEngine {
     });
 
     this.logger.log(`cancelled workflow run with id ${runId}`);
+
+    await this.notifyParentOfChildTerminalRun(run);
 
     return run;
   }
@@ -849,7 +961,7 @@ export class WorkflowEngine {
                       : {
                           timeline: merge(lockedRun.timeline, {
                             [lockedRun.currentStepId]: {
-                              output: event?.data ?? {},
+                              output: event?.data === undefined ? {} : event.data,
                               ...(isTimeout ? { timedOut: true as const } : {}),
                               timestamp: new Date(),
                             },
@@ -955,6 +1067,61 @@ export class WorkflowEngine {
             { timedOut: false; data: T } | { timedOut: true }
           >;
         },
+        invokeWorkflow: async <
+          TInput extends InputParameters,
+          TOutput = unknown,
+        >(
+          stepId: string,
+          refOrParams:
+            | WorkflowRef<TInput, TOutput>
+            | {
+                workflowId: string;
+                input: unknown;
+                resourceId?: string;
+                idempotencyKey?: string;
+                options?: WorkflowRunOptions;
+              },
+          inputArg?: InferInputParameters<TInput>,
+          optionsArg?: WorkflowRunOptions,
+        ) => {
+          if (!run) {
+            throw new WorkflowEngineError(
+              'Missing workflow run',
+              workflowId,
+              runId,
+            );
+          }
+
+          if (typeof refOrParams === 'function' && 'id' in refOrParams) {
+            return this.invokeWorkflowStep({
+              run,
+              stepId,
+              workflowId: refOrParams.id,
+              input: inputArg,
+              options: optionsArg,
+              resourceId: optionsArg?.resourceId,
+              idempotencyKey: optionsArg?.idempotencyKey,
+            }) as Promise<TOutput>;
+          }
+
+          const params = refOrParams as {
+            workflowId: string;
+            input: unknown;
+            resourceId?: string;
+            idempotencyKey?: string;
+            options?: WorkflowRunOptions;
+          };
+          return this.invokeWorkflowStep({
+            run,
+            stepId,
+            workflowId: params.workflowId,
+            input: params.input,
+            options: params.options,
+            resourceId: params.resourceId ?? params.options?.resourceId,
+            idempotencyKey:
+              params.idempotencyKey ?? params.options?.idempotencyKey,
+          }) as Promise<TOutput>;
+        },
       };
 
       let step = { ...baseStep };
@@ -985,7 +1152,7 @@ export class WorkflowEngine {
         (noParsedSteps || isLastParsedStep || (hasPluginSteps && result !== undefined));
       if (shouldComplete) {
         const normalizedResult = result === undefined ? {} : result;
-        await this.updateRun({
+        const completedRun = await this.updateRun({
           runId,
           resourceId: scopedResourceId,
           data: {
@@ -995,6 +1162,7 @@ export class WorkflowEngine {
             jobId: job?.id,
           },
         });
+        await this.notifyParentOfChildTerminalRun(completedRun);
 
         this.logger.log('Workflow run completed.', {
           runId,
@@ -1006,7 +1174,7 @@ export class WorkflowEngine {
       // are exhausted. pg-boss handles the retry-vs-DLQ decision based on
       // the per-job retryLimit set when the job was enqueued.
       if (runId) {
-        await this.updateRun({
+        const updatedRun = await this.updateRun({
           runId,
           resourceId: scopedResourceId,
           data: {
@@ -1014,6 +1182,13 @@ export class WorkflowEngine {
             jobId: job?.id,
           },
         });
+        if (
+          updatedRun.status === WorkflowStatus.COMPLETED ||
+          updatedRun.status === WorkflowStatus.FAILED ||
+          updatedRun.status === WorkflowStatus.CANCELLED
+        ) {
+          await this.notifyParentOfChildTerminalRun(updatedRun);
+        }
       }
 
       throw error;
@@ -1034,7 +1209,7 @@ export class WorkflowEngine {
     const run = await getWorkflowRun({ runId }, { db: this.db });
     if (!run || run.status !== WorkflowStatus.RUNNING) return;
 
-    await this.updateRun({
+    const failedRun = await this.updateRun({
       runId,
       resourceId: run.resourceId ?? undefined,
       data: {
@@ -1042,6 +1217,7 @@ export class WorkflowEngine {
         error: run.error ?? 'Workflow run worker died or job expired before completion',
       },
     });
+    await this.notifyParentOfChildTerminalRun(failedRun);
 
     this.logger.log('Marked stuck workflow run as failed', {
       runId,
@@ -1067,6 +1243,348 @@ export class WorkflowEngine {
     return entry && typeof entry === 'object' && 'waitFor' in entry
       ? (entry as TimelineWaitForEntry)
       : null;
+  }
+
+  private getInvokeWorkflowStepEntry(
+    timeline: Record<string, unknown>,
+    stepId: string,
+  ): TimelineInvokeWorkflowEntry | null {
+    const entry = timeline[`${stepId}-invoke-workflow`];
+    return entry && typeof entry === 'object' && 'invokeWorkflow' in entry
+      ? (entry as TimelineInvokeWorkflowEntry)
+      : null;
+  }
+
+  private isInvokeWorkflowFailureOutput(
+    output: unknown,
+  ): output is InvokeWorkflowFailureOutput {
+    return (
+      typeof output === 'object' &&
+      output !== null &&
+      '__pgWorkflowsInvokeWorkflowError' in output &&
+      (output as InvokeWorkflowFailureOutput)
+        .__pgWorkflowsInvokeWorkflowError === true
+    );
+  }
+
+  private resolveInvokeWorkflowOutput(output: unknown): unknown {
+    if (!this.isInvokeWorkflowFailureOutput(output)) {
+      return output;
+    }
+
+    throw new WorkflowEngineError(
+      `Child workflow ${output.childWorkflowId} ${output.status}${output.error ? `: ${output.error}` : ''}`,
+      output.childWorkflowId,
+      output.childRunId,
+    );
+  }
+
+  private getInvokeWorkflowTerminalOutput(childRun: WorkflowRun): unknown {
+    if (childRun.status === WorkflowStatus.COMPLETED) {
+      return childRun.output === undefined ? {} : childRun.output;
+    }
+
+    if (
+      childRun.status !== WorkflowStatus.FAILED &&
+      childRun.status !== WorkflowStatus.CANCELLED
+    ) {
+      throw new WorkflowEngineError(
+        `Child workflow ${childRun.workflowId} is not in a terminal status`,
+        childRun.workflowId,
+        childRun.id,
+      );
+    }
+
+    return {
+      __pgWorkflowsInvokeWorkflowError: true,
+      childRunId: childRun.id,
+      childWorkflowId: childRun.workflowId,
+      status:
+        childRun.status === WorkflowStatus.FAILED
+          ? WorkflowStatus.FAILED
+          : WorkflowStatus.CANCELLED,
+      ...(childRun.error ? { error: childRun.error } : {}),
+    } satisfies InvokeWorkflowFailureOutput;
+  }
+
+  private assertInvokeWorkflowChildMatches({
+    childRun,
+    parentRun,
+    stepId,
+    workflowId,
+  }: {
+    childRun: WorkflowRun;
+    parentRun: WorkflowRun;
+    stepId: string;
+    workflowId: string;
+  }) {
+    const expectedParentResourceId = parentRun.resourceId ?? null;
+    const matches =
+      childRun.workflowId === workflowId &&
+      childRun.parentRunId === parentRun.id &&
+      childRun.parentStepId === stepId &&
+      childRun.parentResourceId === expectedParentResourceId;
+
+    if (!matches) {
+      throw new WorkflowEngineError(
+        `Idempotency key resolved to workflow run ${childRun.id}, which does not belong to invokeWorkflow step '${stepId}'`,
+        workflowId,
+        parentRun.id,
+      );
+    }
+  }
+
+  // The whole step runs inside a single SELECT … FOR UPDATE transaction so that
+  // every state transition (cache hit, terminal-child cache, fresh child create,
+  // re-pause for a still-running existing child) sees a consistent parent row
+  // and can never overwrite a status another worker just wrote (e.g. a
+  // concurrent invoke-completion event flipping the parent to COMPLETED).
+  //
+  // The child enqueue is intentionally moved OUT of the transaction so we don't
+  // dispatch a child job that could race the parent's commit. This mirrors the
+  // post-commit + revert-on-failure pattern used by waitStep/pollStep; the
+  // re-send semantics are still safe because the existingInvoke branch detects
+  // the already-created child on retry and re-pauses without re-creating it.
+  private async invokeWorkflowStep({
+    run,
+    stepId,
+    workflowId,
+    input,
+    resourceId,
+    idempotencyKey,
+    options,
+  }: {
+    run: WorkflowRun;
+    stepId: string;
+    workflowId: string;
+    input: unknown;
+    resourceId?: string;
+    idempotencyKey?: string;
+    options?: WorkflowRunOptions;
+  }): Promise<unknown> {
+    let invokeOutput: unknown;
+    let hasInvokeOutput = false;
+    let childRunToEnqueue: WorkflowRun | undefined;
+    let parentRunForRevert: WorkflowRun = run;
+    const childResourceId = resourceId ?? run.resourceId ?? undefined;
+    const childIdempotencyKey = idempotencyKey;
+
+    await withPostgresTransaction(
+      this.db,
+      async (db) => {
+        const lockedRun = await this.getRun(
+          { runId: run.id, resourceId: run.resourceId ?? undefined },
+          { exclusiveLock: true, db },
+        );
+        parentRunForRevert = lockedRun;
+
+        if (
+          lockedRun.status === WorkflowStatus.CANCELLED ||
+          lockedRun.status === WorkflowStatus.PAUSED ||
+          lockedRun.status === WorkflowStatus.FAILED
+        ) {
+          return;
+        }
+
+        const lockedCached = this.getCachedStepEntry(
+          lockedRun.timeline,
+          stepId,
+        );
+        if (lockedCached?.output !== undefined) {
+          invokeOutput = lockedCached.output;
+          hasInvokeOutput = true;
+          return;
+        }
+
+        const lockedInvoke = this.getInvokeWorkflowStepEntry(
+          lockedRun.timeline,
+          stepId,
+        );
+        if (lockedInvoke) {
+          const existingChildRun = await this.getRun({
+            runId: lockedInvoke.invokeWorkflow.childRunId,
+          });
+          if (
+            existingChildRun.status === WorkflowStatus.COMPLETED ||
+            existingChildRun.status === WorkflowStatus.FAILED ||
+            existingChildRun.status === WorkflowStatus.CANCELLED
+          ) {
+            invokeOutput =
+              this.getInvokeWorkflowTerminalOutput(existingChildRun);
+            hasInvokeOutput = true;
+            await this.updateRun(
+              {
+                runId: run.id,
+                resourceId: run.resourceId ?? undefined,
+                data: {
+                  timeline: merge(lockedRun.timeline, {
+                    [stepId]: {
+                      output: invokeOutput,
+                      timestamp: new Date(),
+                    },
+                  }),
+                },
+              },
+              { db },
+            );
+            return;
+          }
+
+          await this.pauseForChildWorkflow({
+            run: lockedRun,
+            stepId,
+            childRun: existingChildRun,
+            db,
+          });
+          childRunToEnqueue = existingChildRun;
+          return;
+        }
+
+        const result = await this.createWorkflowRun({
+          workflowId,
+          input,
+          resourceId: childResourceId,
+          idempotencyKey: childIdempotencyKey,
+          options,
+          parentRunId: run.id,
+          parentStepId: stepId,
+          parentResourceId: run.resourceId ?? undefined,
+          enqueue: false,
+          db,
+        });
+        const childRun = result.run;
+
+        if (!result.created) {
+          this.assertInvokeWorkflowChildMatches({
+            childRun,
+            parentRun: lockedRun,
+            stepId,
+            workflowId,
+          });
+
+          if (
+            childRun.status === WorkflowStatus.COMPLETED ||
+            childRun.status === WorkflowStatus.FAILED ||
+            childRun.status === WorkflowStatus.CANCELLED
+          ) {
+            invokeOutput = this.getInvokeWorkflowTerminalOutput(childRun);
+            hasInvokeOutput = true;
+            await this.updateRun(
+              {
+                runId: run.id,
+                resourceId: run.resourceId ?? undefined,
+                data: {
+                  timeline: merge(lockedRun.timeline, {
+                    [`${stepId}-invoke-workflow`]: {
+                      invokeWorkflow: {
+                        childRunId: childRun.id,
+                        childWorkflowId: childRun.workflowId,
+                      },
+                      timestamp: new Date(),
+                    },
+                    [stepId]: {
+                      output: invokeOutput,
+                      timestamp: new Date(),
+                    },
+                  }),
+                },
+              },
+              { db },
+            );
+            return;
+          }
+        }
+
+        await this.pauseForChildWorkflow({
+          run: lockedRun,
+          stepId,
+          childRun,
+          db,
+          timeline: merge(lockedRun.timeline, {
+            [`${stepId}-invoke-workflow`]: {
+              invokeWorkflow: {
+                childRunId: childRun.id,
+                childWorkflowId: childRun.workflowId,
+              },
+              timestamp: new Date(),
+            },
+          }),
+        });
+
+        childRunToEnqueue = childRun;
+      },
+      this.pool,
+    );
+
+    if (hasInvokeOutput) {
+      return this.resolveInvokeWorkflowOutput(invokeOutput);
+    }
+
+    if (childRunToEnqueue) {
+      await this.enqueueChildWorkflowAfterParentPause({
+        parentRun: parentRunForRevert,
+        childRun: childRunToEnqueue,
+        options,
+      });
+    }
+  }
+
+  private async enqueueChildWorkflowAfterParentPause({
+    parentRun,
+    childRun,
+    options,
+  }: {
+    parentRun: WorkflowRun;
+    childRun: WorkflowRun;
+    options?: WorkflowRunOptions;
+  }) {
+    try {
+      await this.enqueueWorkflowRun(childRun, options);
+    } catch (error) {
+      await this.updateRun({
+        runId: parentRun.id,
+        resourceId: parentRun.resourceId ?? undefined,
+        data: {
+          status: WorkflowStatus.RUNNING,
+          pausedAt: null,
+        },
+      });
+      throw error;
+    }
+  }
+
+  private async pauseForChildWorkflow({
+    run,
+    stepId,
+    childRun,
+    db,
+    timeline,
+  }: {
+    run: WorkflowRun;
+    stepId: string;
+    childRun: WorkflowRun;
+    db?: Db;
+    timeline?: Record<string, unknown>;
+  }) {
+    const baseTimeline = timeline ?? run.timeline;
+    await this.updateRun(
+      {
+        runId: run.id,
+        resourceId: run.resourceId ?? undefined,
+        data: {
+          status: WorkflowStatus.PAUSED,
+          currentStepId: stepId,
+          pausedAt: new Date(),
+          timeline: merge(baseTimeline, {
+            [`${stepId}-wait-for`]: {
+              waitFor: { eventName: getInvokeWorkflowEventName(childRun.id) },
+              timestamp: new Date(),
+            },
+          }),
+        },
+      },
+      { db },
+    );
   }
 
   private async runStep({

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -4,9 +4,12 @@ import { type Db, type JobWithMetadata, PgBoss } from 'pg-boss';
 import { parseWorkflowHandler } from './ast-parser';
 import {
   DEFAULT_PGBOSS_SCHEMA,
+  invokeWorkflowTimelineKey,
+  isInvokeWorkflowTimelineEntry,
   PAUSE_EVENT_NAME,
   WORKFLOW_RUN_DLQ_QUEUE_NAME,
   WORKFLOW_RUN_QUEUE_NAME,
+  waitForTimelineKey,
 } from './constants';
 import { runMigrations } from './db/migration';
 import {
@@ -47,6 +50,14 @@ type StartWorkflowOptions = WorkflowRunOptions & {
   batchSize?: number;
 };
 
+type ResolvedWorkflowRunParameters<TOptions extends WorkflowRunOptions = WorkflowRunOptions> = {
+  workflowId: string;
+  input: unknown;
+  resourceId?: string;
+  idempotencyKey?: string;
+  options?: TOptions;
+};
+
 export type WorkflowEngineOptions = {
   workflows?: WorkflowDefinition[];
   logger?: WorkflowLogger;
@@ -83,16 +94,9 @@ type TimelineInvokeWorkflowEntry = {
   invokeWorkflow: {
     childRunId: string;
     childWorkflowId: string;
+    childResourceId?: string | null;
   };
   timestamp: Date;
-};
-
-type InvokeWorkflowFailureOutput = {
-  __pgWorkflowsInvokeWorkflowError: true;
-  childRunId: string;
-  childWorkflowId: string;
-  status: WorkflowStatus.FAILED | WorkflowStatus.CANCELLED;
-  error?: string;
 };
 
 type WorkflowRunJobParameters = {
@@ -302,6 +306,49 @@ export class WorkflowEngine {
     return this;
   }
 
+  private resolveWorkflowRunParameters<
+    TInput extends InputParameters,
+    TOptions extends WorkflowRunOptions,
+  >(
+    refOrParams:
+      | WorkflowRef<TInput, unknown>
+      | {
+          resourceId?: string;
+          workflowId: string;
+          input: unknown;
+          idempotencyKey?: string;
+          options?: TOptions;
+        },
+    inputArg?: InferInputParameters<TInput>,
+    optionsArg?: TOptions,
+  ): ResolvedWorkflowRunParameters<TOptions> {
+    if (typeof refOrParams === 'function' && 'id' in refOrParams) {
+      return {
+        workflowId: refOrParams.id,
+        input: inputArg,
+        options: optionsArg,
+        resourceId: optionsArg?.resourceId,
+        idempotencyKey: optionsArg?.idempotencyKey,
+      };
+    }
+
+    const params = refOrParams as {
+      resourceId?: string;
+      workflowId: string;
+      input: unknown;
+      idempotencyKey?: string;
+      options?: TOptions;
+    };
+
+    return {
+      workflowId: params.workflowId,
+      input: params.input,
+      resourceId: params.resourceId ?? params.options?.resourceId,
+      idempotencyKey: params.idempotencyKey ?? params.options?.idempotencyKey,
+      options: params.options,
+    };
+  }
+
   async startWorkflow<TInput extends InputParameters>(
     ref: WorkflowRef<TInput>,
     input: InferInputParameters<TInput>,
@@ -329,32 +376,8 @@ export class WorkflowEngine {
     inputArg?: InferInputParameters<TInput>,
     optionsArg?: StartWorkflowOptions,
   ): Promise<WorkflowRun> {
-    let workflowId: string;
-    let input: unknown;
-    let resourceId: string | undefined;
-    let idempotencyKey: string | undefined;
-    let options: StartWorkflowOptions | undefined;
-
-    if (typeof refOrParams === 'function' && 'id' in refOrParams) {
-      workflowId = refOrParams.id;
-      input = inputArg;
-      options = optionsArg;
-      resourceId = optionsArg?.resourceId;
-      idempotencyKey = optionsArg?.idempotencyKey;
-    } else {
-      const params = refOrParams as {
-        resourceId?: string;
-        workflowId: string;
-        input: unknown;
-        idempotencyKey?: string;
-        options?: StartWorkflowOptions;
-      };
-      workflowId = params.workflowId;
-      input = params.input;
-      resourceId = params.resourceId;
-      idempotencyKey = params.idempotencyKey;
-      options = params.options;
-    }
+    const { workflowId, input, resourceId, idempotencyKey, options } =
+      this.resolveWorkflowRunParameters(refOrParams, inputArg, optionsArg);
 
     if (!this._started) {
       await this.start(false, { batchSize: options?.batchSize ?? 1 });
@@ -432,21 +455,23 @@ export class WorkflowEngine {
         ? new Date(Date.now() + workflow.timeout)
         : null;
 
-    const insertRun = async (targetDb: Db) => await insertWorkflowRun({
-        resourceId,
-        workflowId,
-        currentStepId: initialStepId,
-        status: WorkflowStatus.RUNNING,
-        input,
-        maxRetries: options?.retries ?? workflow.retries ?? 0,
-        timeoutAt,
-        idempotencyKey,
-        parentRunId,
-        parentStepId,
-        parentResourceId,
-      },
-      targetDb,
-    );
+    const insertRun = async (targetDb: Db) =>
+      await insertWorkflowRun(
+        {
+          resourceId,
+          workflowId,
+          currentStepId: initialStepId,
+          status: WorkflowStatus.RUNNING,
+          input,
+          maxRetries: options?.retries ?? workflow.retries ?? 0,
+          timeoutAt,
+          idempotencyKey,
+          parentRunId,
+          parentStepId,
+          parentResourceId,
+        },
+        targetDb,
+      );
 
     const { run, created } = db
       ? await insertRun(db)
@@ -455,7 +480,12 @@ export class WorkflowEngine {
           async (transactionDb) => {
             const result = await insertRun(transactionDb);
             if (enqueue && result.created) {
-              await this.enqueueWorkflowRun(result.run, options);
+              // Pipe the same transaction connection through pg-boss so the
+              // INSERT into workflow_runs and the INSERT into pgboss.job
+              // commit (or roll back) together. If `boss.send` throws, the
+              // workflow_runs row is rolled back too, so we never end up with
+              // an orphan run that has no job, or a job that points at no run.
+              await this.enqueueWorkflowRun(result.run, options, transactionDb);
             }
             return result;
           },
@@ -472,6 +502,7 @@ export class WorkflowEngine {
   private async enqueueWorkflowRun(
     run: WorkflowRun,
     options?: { expireInSeconds?: number },
+    db?: Db,
   ) {
     const job: WorkflowRunJobParameters = {
       runId: run.id,
@@ -484,6 +515,7 @@ export class WorkflowEngine {
       startAfter: new Date(),
       expireInSeconds: options?.expireInSeconds ?? defaultExpireInSeconds,
       ...retrySendOptions(run.maxRetries),
+      ...(db ? { db } : {}),
     });
   }
 
@@ -508,20 +540,10 @@ export class WorkflowEngine {
       return;
     }
 
-    const job: WorkflowRunJobParameters = {
+    await this.triggerEvent({
       runId: parentRun.id,
       resourceId: parentRun.resourceId ?? undefined,
-      workflowId: parentRun.workflowId,
-      input: parentRun.input,
-      event: {
-        name: getInvokeWorkflowEventName(childRun.id),
-        data: this.getInvokeWorkflowTerminalOutput(childRun),
-      },
-    };
-
-    await this.boss.send(WORKFLOW_RUN_QUEUE_NAME, job, {
-      expireInSeconds: defaultExpireInSeconds,
-      ...retrySendOptions(parentRun.maxRetries),
+      eventName: getInvokeWorkflowEventName(childRun.id),
     });
   }
 
@@ -961,7 +983,7 @@ export class WorkflowEngine {
                       : {
                           timeline: merge(lockedRun.timeline, {
                             [lockedRun.currentStepId]: {
-                              output: event?.data === undefined ? {} : event.data,
+                              output: event?.data ?? {},
                               ...(isTimeout ? { timedOut: true as const } : {}),
                               timestamp: new Date(),
                             },
@@ -1067,10 +1089,7 @@ export class WorkflowEngine {
             { timedOut: false; data: T } | { timedOut: true }
           >;
         },
-        invokeWorkflow: async <
-          TInput extends InputParameters,
-          TOutput = unknown,
-        >(
+        invokeWorkflow: async <TInput extends InputParameters, TOutput = unknown>(
           stepId: string,
           refOrParams:
             | WorkflowRef<TInput, TOutput>
@@ -1085,41 +1104,18 @@ export class WorkflowEngine {
           optionsArg?: WorkflowRunOptions,
         ) => {
           if (!run) {
-            throw new WorkflowEngineError(
-              'Missing workflow run',
-              workflowId,
-              runId,
-            );
+            throw new WorkflowEngineError('Missing workflow run', workflowId, runId);
           }
 
-          if (typeof refOrParams === 'function' && 'id' in refOrParams) {
-            return this.invokeWorkflowStep({
-              run,
-              stepId,
-              workflowId: refOrParams.id,
-              input: inputArg,
-              options: optionsArg,
-              resourceId: optionsArg?.resourceId,
-              idempotencyKey: optionsArg?.idempotencyKey,
-            }) as Promise<TOutput>;
-          }
-
-          const params = refOrParams as {
-            workflowId: string;
-            input: unknown;
-            resourceId?: string;
-            idempotencyKey?: string;
-            options?: WorkflowRunOptions;
-          };
+          const params = this.resolveWorkflowRunParameters(refOrParams, inputArg, optionsArg);
           return this.invokeWorkflowStep({
             run,
             stepId,
             workflowId: params.workflowId,
             input: params.input,
             options: params.options,
-            resourceId: params.resourceId ?? params.options?.resourceId,
-            idempotencyKey:
-              params.idempotencyKey ?? params.options?.idempotencyKey,
+            resourceId: params.resourceId,
+            idempotencyKey: params.idempotencyKey,
           }) as Promise<TOutput>;
         },
       };
@@ -1239,7 +1235,7 @@ export class WorkflowEngine {
     timeline: Record<string, unknown>,
     stepId: string,
   ): TimelineWaitForEntry | null {
-    const entry = timeline[`${stepId}-wait-for`];
+    const entry = timeline[waitForTimelineKey(stepId)];
     return entry && typeof entry === 'object' && 'waitFor' in entry
       ? (entry as TimelineWaitForEntry)
       : null;
@@ -1249,62 +1245,32 @@ export class WorkflowEngine {
     timeline: Record<string, unknown>,
     stepId: string,
   ): TimelineInvokeWorkflowEntry | null {
-    const entry = timeline[`${stepId}-invoke-workflow`];
-    return entry && typeof entry === 'object' && 'invokeWorkflow' in entry
-      ? (entry as TimelineInvokeWorkflowEntry)
-      : null;
+    const entry = timeline[invokeWorkflowTimelineKey(stepId)];
+    return isInvokeWorkflowTimelineEntry(entry) ? (entry as TimelineInvokeWorkflowEntry) : null;
   }
 
-  private isInvokeWorkflowFailureOutput(
-    output: unknown,
-  ): output is InvokeWorkflowFailureOutput {
-    return (
-      typeof output === 'object' &&
-      output !== null &&
-      '__pgWorkflowsInvokeWorkflowError' in output &&
-      (output as InvokeWorkflowFailureOutput)
-        .__pgWorkflowsInvokeWorkflowError === true
-    );
+  /**
+   * Returns the cached output for a COMPLETED child run. Treats `undefined`
+   * outputs as `{}` so the parent timeline always has a defined value.
+   * Caller must ensure `childRun.status === COMPLETED` before calling.
+   */
+  private getCompletedChildOutput(childRun: WorkflowRun): unknown {
+    return childRun.output === undefined ? {} : childRun.output;
   }
 
-  private resolveInvokeWorkflowOutput(output: unknown): unknown {
-    if (!this.isInvokeWorkflowFailureOutput(output)) {
-      return output;
-    }
-
+  /**
+   * Throws a `WorkflowEngineError` describing why an invoked child run did not
+   * produce output (it FAILED or was CANCELLED). The throw aborts the parent
+   * step, which is then caught by `handleWorkflowRun` and marks the parent
+   * FAILED with the same message — no fake sentinel value is ever written to
+   * the parent timeline.
+   */
+  private throwForNonCompletedChild(childRun: WorkflowRun): never {
     throw new WorkflowEngineError(
-      `Child workflow ${output.childWorkflowId} ${output.status}${output.error ? `: ${output.error}` : ''}`,
-      output.childWorkflowId,
-      output.childRunId,
+      `Child workflow ${childRun.workflowId} ${childRun.status}${childRun.error ? `: ${childRun.error}` : ''}`,
+      childRun.workflowId,
+      childRun.id,
     );
-  }
-
-  private getInvokeWorkflowTerminalOutput(childRun: WorkflowRun): unknown {
-    if (childRun.status === WorkflowStatus.COMPLETED) {
-      return childRun.output === undefined ? {} : childRun.output;
-    }
-
-    if (
-      childRun.status !== WorkflowStatus.FAILED &&
-      childRun.status !== WorkflowStatus.CANCELLED
-    ) {
-      throw new WorkflowEngineError(
-        `Child workflow ${childRun.workflowId} is not in a terminal status`,
-        childRun.workflowId,
-        childRun.id,
-      );
-    }
-
-    return {
-      __pgWorkflowsInvokeWorkflowError: true,
-      childRunId: childRun.id,
-      childWorkflowId: childRun.workflowId,
-      status:
-        childRun.status === WorkflowStatus.FAILED
-          ? WorkflowStatus.FAILED
-          : WorkflowStatus.CANCELLED,
-      ...(childRun.error ? { error: childRun.error } : {}),
-    } satisfies InvokeWorkflowFailureOutput;
   }
 
   private assertInvokeWorkflowChildMatches({
@@ -1386,31 +1352,25 @@ export class WorkflowEngine {
           return;
         }
 
-        const lockedCached = this.getCachedStepEntry(
-          lockedRun.timeline,
-          stepId,
-        );
+        const lockedCached = this.getCachedStepEntry(lockedRun.timeline, stepId);
         if (lockedCached?.output !== undefined) {
           invokeOutput = lockedCached.output;
           hasInvokeOutput = true;
           return;
         }
 
-        const lockedInvoke = this.getInvokeWorkflowStepEntry(
-          lockedRun.timeline,
-          stepId,
-        );
+        const lockedInvoke = this.getInvokeWorkflowStepEntry(lockedRun.timeline, stepId);
         if (lockedInvoke) {
+          const existingChildResourceId =
+            'childResourceId' in lockedInvoke.invokeWorkflow
+              ? (lockedInvoke.invokeWorkflow.childResourceId ?? undefined)
+              : childResourceId;
           const existingChildRun = await this.getRun({
             runId: lockedInvoke.invokeWorkflow.childRunId,
+            resourceId: existingChildResourceId,
           });
-          if (
-            existingChildRun.status === WorkflowStatus.COMPLETED ||
-            existingChildRun.status === WorkflowStatus.FAILED ||
-            existingChildRun.status === WorkflowStatus.CANCELLED
-          ) {
-            invokeOutput =
-              this.getInvokeWorkflowTerminalOutput(existingChildRun);
+          if (existingChildRun.status === WorkflowStatus.COMPLETED) {
+            invokeOutput = this.getCompletedChildOutput(existingChildRun);
             hasInvokeOutput = true;
             await this.updateRun(
               {
@@ -1429,11 +1389,21 @@ export class WorkflowEngine {
             );
             return;
           }
+          if (
+            existingChildRun.status === WorkflowStatus.FAILED ||
+            existingChildRun.status === WorkflowStatus.CANCELLED
+          ) {
+            // No timeline write — let the throw roll back the txn (a no-op
+            // here since we only did SELECTs) and bubble up so the parent
+            // is marked FAILED by the worker's catch handler.
+            this.throwForNonCompletedChild(existingChildRun);
+          }
 
-          await this.pauseForChildWorkflow({
+          await this.pauseRunForWait({
             run: lockedRun,
             stepId,
-            childRun: existingChildRun,
+            eventName: getInvokeWorkflowEventName(existingChildRun.id),
+            skipOutput: true,
             db,
           });
           childRunToEnqueue = existingChildRun;
@@ -1462,12 +1432,8 @@ export class WorkflowEngine {
             workflowId,
           });
 
-          if (
-            childRun.status === WorkflowStatus.COMPLETED ||
-            childRun.status === WorkflowStatus.FAILED ||
-            childRun.status === WorkflowStatus.CANCELLED
-          ) {
-            invokeOutput = this.getInvokeWorkflowTerminalOutput(childRun);
+          if (childRun.status === WorkflowStatus.COMPLETED) {
+            invokeOutput = this.getCompletedChildOutput(childRun);
             hasInvokeOutput = true;
             await this.updateRun(
               {
@@ -1475,10 +1441,11 @@ export class WorkflowEngine {
                 resourceId: run.resourceId ?? undefined,
                 data: {
                   timeline: merge(lockedRun.timeline, {
-                    [`${stepId}-invoke-workflow`]: {
+                    [invokeWorkflowTimelineKey(stepId)]: {
                       invokeWorkflow: {
                         childRunId: childRun.id,
                         childWorkflowId: childRun.workflowId,
+                        childResourceId: childRun.resourceId,
                       },
                       timestamp: new Date(),
                     },
@@ -1493,18 +1460,30 @@ export class WorkflowEngine {
             );
             return;
           }
+          if (
+            childRun.status === WorkflowStatus.FAILED ||
+            childRun.status === WorkflowStatus.CANCELLED
+          ) {
+            // Same throw-and-rollback contract as the existing-child branch:
+            // we deliberately do NOT record the parent timeline binding for
+            // a child we matched-by-idempotency-key but never owned the
+            // creation of. The throw propagates and the parent fails.
+            this.throwForNonCompletedChild(childRun);
+          }
         }
 
-        await this.pauseForChildWorkflow({
+        await this.pauseRunForWait({
           run: lockedRun,
           stepId,
-          childRun,
+          eventName: getInvokeWorkflowEventName(childRun.id),
+          skipOutput: true,
           db,
           timeline: merge(lockedRun.timeline, {
-            [`${stepId}-invoke-workflow`]: {
+            [invokeWorkflowTimelineKey(stepId)]: {
               invokeWorkflow: {
                 childRunId: childRun.id,
                 childWorkflowId: childRun.workflowId,
+                childResourceId: childRun.resourceId,
               },
               timestamp: new Date(),
             },
@@ -1517,11 +1496,11 @@ export class WorkflowEngine {
     );
 
     if (hasInvokeOutput) {
-      return this.resolveInvokeWorkflowOutput(invokeOutput);
+      return invokeOutput;
     }
 
     if (childRunToEnqueue) {
-      await this.enqueueChildWorkflowAfterParentPause({
+      await this.enqueueChildWorkflowAfterParentWaitCommits({
         parentRun: parentRunForRevert,
         childRun: childRunToEnqueue,
         options,
@@ -1529,7 +1508,10 @@ export class WorkflowEngine {
     }
   }
 
-  private async enqueueChildWorkflowAfterParentPause({
+  // Dispatch the child only after the parent's invoke wait is durable. If this
+  // send fails, the parent is made RUNNING again so the step can retry and
+  // re-enqueue the already-created child run.
+  private async enqueueChildWorkflowAfterParentWaitCommits({
     parentRun,
     childRun,
     options,
@@ -1541,32 +1523,63 @@ export class WorkflowEngine {
     try {
       await this.enqueueWorkflowRun(childRun, options);
     } catch (error) {
-      await this.updateRun({
-        runId: parentRun.id,
-        resourceId: parentRun.resourceId ?? undefined,
-        data: {
-          status: WorkflowStatus.RUNNING,
-          pausedAt: null,
-        },
-      });
+      // Only flip back to RUNNING if the parent is still PAUSED. Anything else
+      // (e.g. the parent was cancelled while we were trying to enqueue the
+      // child, or a duplicate notify already woke it) means our PAUSED row is
+      // gone and resurrecting the parent would orphan it without a job.
+      try {
+        await this.updateRun({
+          runId: parentRun.id,
+          resourceId: parentRun.resourceId ?? undefined,
+          data: {
+            status: WorkflowStatus.RUNNING,
+            pausedAt: null,
+          },
+          expectedStatuses: [WorkflowStatus.PAUSED],
+        });
+      } catch (revertError) {
+        // Swallow status-mismatch errors so we still surface the original
+        // enqueue failure as the cause; log everything else for visibility.
+        if (
+          !(
+            revertError instanceof WorkflowEngineError &&
+            revertError.message.includes('Cannot update workflow run')
+          )
+        ) {
+          this.logger.error(
+            'Failed to revert parent run after invoke enqueue failure',
+            revertError as Error,
+            { runId: parentRun.id, workflowId: parentRun.workflowId },
+          );
+        }
+      }
       throw error;
     }
   }
 
-  private async pauseForChildWorkflow({
+  private async pauseRunForWait({
     run,
     stepId,
-    childRun,
+    eventName,
+    timeoutEvent,
+    skipOutput,
     db,
     timeline,
   }: {
     run: WorkflowRun;
     stepId: string;
-    childRun: WorkflowRun;
+    eventName?: string;
+    timeoutEvent?: string;
+    skipOutput?: true;
     db?: Db;
     timeline?: Record<string, unknown>;
   }) {
     const baseTimeline = timeline ?? run.timeline;
+    const waitFor: TimelineWaitForEntry['waitFor'] = {};
+    if (eventName) waitFor.eventName = eventName;
+    if (timeoutEvent) waitFor.timeoutEvent = timeoutEvent;
+    if (skipOutput) waitFor.skipOutput = true;
+
     await this.updateRun(
       {
         runId: run.id,
@@ -1576,8 +1589,8 @@ export class WorkflowEngine {
           currentStepId: stepId,
           pausedAt: new Date(),
           timeline: merge(baseTimeline, {
-            [`${stepId}-wait-for`]: {
-              waitFor: { eventName: getInvokeWorkflowEventName(childRun.id) },
+            [waitForTimelineKey(stepId)]: {
+              waitFor,
               timestamp: new Date(),
             },
           }),
@@ -1728,24 +1741,7 @@ export class WorkflowEngine {
           { runId: run.id, resourceId: run.resourceId ?? undefined },
           { exclusiveLock: true, db },
         );
-        return this.updateRun(
-          {
-            runId: run.id,
-            resourceId: run.resourceId ?? undefined,
-            data: {
-              status: WorkflowStatus.PAUSED,
-              currentStepId: stepId,
-              pausedAt: new Date(),
-              timeline: merge(freshRun.timeline, {
-                [`${stepId}-wait-for`]: {
-                  waitFor: { eventName, timeoutEvent },
-                  timestamp: new Date(),
-                },
-              }),
-            },
-          },
-          { db },
-        );
+        return this.pauseRunForWait({ run: freshRun, stepId, eventName, timeoutEvent, db });
       },
       this.pool,
     );
@@ -1931,7 +1927,7 @@ export class WorkflowEngine {
               pausedAt: new Date(),
               timeline: merge(freshRun.timeline, {
                 [`${stepId}-poll`]: { startedAt: startedAt.toISOString() },
-                [`${stepId}-wait-for`]: {
+                [waitForTimelineKey(stepId)]: {
                   waitFor: { timeoutEvent: pollEvent, skipOutput: true },
                   timestamp: new Date(),
                 },

--- a/src/migration-lock.integration.test.ts
+++ b/src/migration-lock.integration.test.ts
@@ -55,7 +55,7 @@ describe('Migration advisory lock (real PostgreSQL)', () => {
 
     // Verify the final schema state is correct
     const versionResult = await pool.query('SELECT version FROM workflow_schema_version LIMIT 1');
-    expect(versionResult.rows[0].version).toBe(3);
+    expect(versionResult.rows[0].version).toBe(4);
 
     const tableExists = await pool.query(`
       SELECT EXISTS (
@@ -64,6 +64,22 @@ describe('Migration advisory lock (real PostgreSQL)', () => {
       )
     `);
     expect(tableExists.rows[0].exists).toBe(true);
+
+    const parentColumnResult = await pool.query(
+      `
+        SELECT column_name
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'workflow_runs'
+          AND column_name = ANY($1)
+      `,
+      [['parent_run_id', 'parent_step_id', 'parent_resource_id']],
+    );
+    expect(parentColumnResult.rows.map((row) => row.column_name).sort()).toEqual([
+      'parent_resource_id',
+      'parent_run_id',
+      'parent_step_id',
+    ]);
   });
 
   it('should skip migrations on subsequent starts when schema is up to date', async () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,10 +18,19 @@ export enum StepType {
   WAIT_UNTIL = 'waitUntil',
   DELAY = 'delay',
   POLL = 'poll',
+  INVOKE_WORKFLOW = 'invokeWorkflow',
 }
 
 export type InputParameters = StandardSchemaV1;
 export type InferInputParameters<P extends InputParameters> = StandardSchemaV1.InferOutput<P>;
+
+export type WorkflowRunOptions = {
+  resourceId?: string;
+  timeout?: number;
+  retries?: number;
+  expireInSeconds?: number;
+  idempotencyKey?: string;
+};
 
 export type WorkflowOptions<I extends InputParameters> = {
   timeout?: number;
@@ -56,6 +65,24 @@ export type StepBaseContext = {
     conditionFn: () => Promise<T | false>,
     options?: { interval?: Duration; timeout?: Duration },
   ) => Promise<{ timedOut: false; data: T } | { timedOut: true }>;
+  invokeWorkflow: {
+    <TInput extends InputParameters, TOutput = unknown>(
+      stepId: string,
+      ref: WorkflowRef<TInput, TOutput>,
+      input: InferInputParameters<TInput>,
+      options?: WorkflowRunOptions,
+    ): Promise<TOutput>;
+    <TOutput = unknown>(
+      stepId: string,
+      params: {
+        workflowId: string;
+        input: unknown;
+        resourceId?: string;
+        idempotencyKey?: string;
+        options?: WorkflowRunOptions;
+      },
+    ): Promise<TOutput>;
+  };
 };
 
 /**
@@ -116,10 +143,10 @@ export interface WorkflowFactory<TStepExt = object> {
   use<TNewExt>(
     plugin: WorkflowPlugin<StepBaseContext & TStepExt, TNewExt>,
   ): WorkflowFactory<TStepExt & TNewExt>;
-  ref<TInput extends InputParameters = InputParameters>(
+  ref<TInput extends InputParameters = InputParameters, TOutput = unknown>(
     id: string,
     options?: { inputSchema?: TInput },
-  ): WorkflowRef<TInput>;
+  ): WorkflowRef<TInput, TOutput>;
 }
 
 /**
@@ -129,7 +156,11 @@ export interface WorkflowFactory<TStepExt = object> {
  *
  * Callable: pass a handler to create a full WorkflowDefinition.
  */
-export interface WorkflowRef<TInput extends InputParameters = InputParameters> {
+export interface WorkflowRef<
+  TInput extends InputParameters = InputParameters,
+  // biome-ignore lint/correctness/noUnusedVariables: phantom type carried for typed return inference
+  TOutput = unknown,
+> {
   (
     handler: (context: WorkflowContext<TInput, StepBaseContext>) => Promise<unknown>,
     options?: Omit<WorkflowOptions<TInput>, 'inputSchema'>,

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,7 @@ export enum StepType {
   WAIT_UNTIL = 'waitUntil',
   DELAY = 'delay',
   POLL = 'poll',
-  INVOKE_WORKFLOW = 'invokeWorkflow',
+  INVOKE_CHILD_WORKFLOW = 'invokeChildWorkflow',
 }
 
 export type InputParameters = StandardSchemaV1;
@@ -65,7 +65,11 @@ export type StepBaseContext = {
     conditionFn: () => Promise<T | false>,
     options?: { interval?: Duration; timeout?: Duration },
   ) => Promise<{ timedOut: false; data: T } | { timedOut: true }>;
-  invokeWorkflow: {
+  /**
+   * Invoke a child workflow from inside the current workflow and pause until
+   * the child run reaches a terminal state.
+   */
+  invokeChildWorkflow: {
     <TInput extends InputParameters, TOutput = unknown>(
       stepId: string,
       ref: WorkflowRef<TInput, TOutput>,


### PR DESCRIPTION
## Summary

Adds `step.invokeWorkflow()` so a workflow can start another workflow and wait for its result as a durable step.

This is useful for breaking larger workflows into smaller reusable workflows without keeping a parent worker busy while the child runs.

## How it works

`step.invokeWorkflow()` can be called with either a typed `WorkflowRef` or a workflow ID.

When the parent reaches the step, the engine creates the child run, records the parent/child relationship, and pauses the parent on an internal wait. When the child finishes, it wakes the parent:

- completed children resume the parent with the child output
- failed or cancelled children make the parent step throw
- replays reuse the existing child run instead of starting a duplicate

The parent stays paused while waiting, matching the existing durable wait model used by `waitFor`, `delay`, `poll`, and `pause`.

## Tradeoffs

Cancelling or timing out the parent does not cancel the child. The child continues to its own terminal state, and any later wakeup is ignored if the parent is no longer paused.

Manual resume and fast-forward are no-ops for `invokeWorkflow` waits. The parent only moves forward when the child completes, fails, or is cancelled.

## Testing

Added coverage for successful child completion, replay/idempotency behavior, child failure and cancellation, null outputs, enqueue retry behavior, duplicate wakeups, fast-forward/resume no-op behavior, and AST parsing for `invokeWorkflow` steps.