### PR TITLE
fix: enqueue invoked child workflow inside the parent-pause txn

### DIFF
--- a/src/engine.test.ts
+++ b/src/engine.test.ts
@@ -994,73 +994,6 @@ describe('WorkflowEngine', () => {
         });
     });
 
-    it('should enqueue child workflow only after parent invoke wait is committed', async () => {
-      const childWorkflow = workflow('invoke-child-post-commit', async ({ step }) => {
-        await step.waitFor('child-wait', { eventName: 'child-ready' });
-        return { ok: true };
-      });
-
-      const parentWorkflow = workflow('invoke-parent-post-commit', async ({ step }) => {
-        return await step.invokeChildWorkflow('call-child', {
-          workflowId: 'invoke-child-post-commit',
-          input: {},
-        });
-      });
-
-      await engine.registerWorkflow(childWorkflow);
-      await engine.registerWorkflow(parentWorkflow);
-
-      const originalSend = testBoss.send.bind(testBoss);
-      let observedCommittedParentWait = false;
-      const sendSpy = vi
-        .spyOn(testBoss, 'send')
-        .mockImplementation(async (queue, data, options) => {
-          const job = data as { runId?: string; workflowId?: string };
-          if (queue === WORKFLOW_RUN_QUEUE_NAME && job.workflowId === 'invoke-child-post-commit') {
-            const childRun = await engine.getRun({ runId: job.runId ?? '' });
-            expect(childRun.parentRunId).toBeTruthy();
-
-            const parentRun = await engine.getRun({
-              runId: childRun.parentRunId ?? '',
-              resourceId: childRun.parentResourceId ?? undefined,
-            });
-            expect(parentRun.status).toBe(WorkflowStatus.PAUSED);
-            expect(parentRun.timeline).toMatchObject({
-              'call-child-invoke-child-workflow': {
-                invokeChildWorkflow: {
-                  childRunId: childRun.id,
-                  childWorkflowId: 'invoke-child-post-commit',
-                },
-              },
-              'call-child-wait-for': {
-                waitFor: {
-                  eventName: `__invoke_child_workflow_completed:${childRun.id}`,
-                  skipOutput: true,
-                },
-              },
-            });
-            observedCommittedParentWait = true;
-          }
-
-          return await originalSend(queue, data, options);
-        });
-
-      try {
-        const parentRun = await engine.startWorkflow({
-          resourceId,
-          workflowId: 'invoke-parent-post-commit',
-          input: {},
-        });
-
-        await expect.poll(() => observedCommittedParentWait).toBe(true);
-        await expect
-          .poll(async () => (await engine.getRun({ runId: parentRun.id, resourceId })).status)
-          .toBe(WorkflowStatus.PAUSED);
-      } finally {
-        sendSpy.mockRestore();
-      }
-    });
-
     it('should preserve null output from an invoked child workflow', async () => {
       const childWorkflow = workflow('invoke-child-null-output', async ({ step }) => {
         return await step.run('child-step', async () => null);
@@ -1350,7 +1283,7 @@ describe('WorkflowEngine', () => {
         });
     });
 
-    it('should retry cleanly when child enqueue fails after parent pause is prepared', async () => {
+    it('should roll back the entire invoke txn when child enqueue fails and recreate a fresh child on retry', async () => {
       const childWorkflow = workflow('invoke-child-enqueue-retry', async ({ step }) => {
         return await step.run('child-step', async () => ({ ok: true }));
       });
@@ -1404,6 +1337,10 @@ describe('WorkflowEngine', () => {
           });
 
         expect(rejectedChildEnqueue).toBe(true);
+        // First attempt's enqueue throws inside the parent-pause txn, rolling
+        // back both the child INSERT and the parent pause. The retry then
+        // creates a fresh child and enqueues it successfully — so exactly one
+        // committed child run remains.
         expect(childEnqueueAttempts).toBe(2);
         const childRuns = await engine.getRuns({
           resourceId,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -473,28 +473,22 @@ export class WorkflowEngine {
         targetDb,
       );
 
-    const { run, created } = db
-      ? await insertRun(db)
-      : await withPostgresTransaction(
-          this.boss.getDb(),
-          async (transactionDb) => {
-            const result = await insertRun(transactionDb);
-            if (enqueue && result.created) {
-              // Pipe the same transaction connection through pg-boss so the
-              // INSERT into workflow_runs and the INSERT into pgboss.job
-              // commit (or roll back) together. If `boss.send` throws, the
-              // workflow_runs row is rolled back too, so we never end up with
-              // an orphan run that has no job, or a job that points at no run.
-              await this.enqueueWorkflowRun(result.run, options, transactionDb);
-            }
-            return result;
-          },
-          this.pool,
-        );
+    // Pipe the same transaction connection through pg-boss so the
+    // INSERT into workflow_runs and the INSERT into pgboss.job
+    // commit (or roll back) together. If `boss.send` throws, the
+    // workflow_runs row is rolled back too, so we never end up with
+    // an orphan run that has no job, or a job that points at no run.
+    const insertAndEnqueue = async (targetDb: Db) => {
+      const result = await insertRun(targetDb);
+      if (enqueue && result.created) {
+        await this.enqueueWorkflowRun(result.run, options, targetDb);
+      }
+      return result;
+    };
 
-    if (db && enqueue && created) {
-      await this.enqueueWorkflowRun(run, options);
-    }
+    const { run, created } = db
+      ? await insertAndEnqueue(db)
+      : await withPostgresTransaction(this.boss.getDb(), insertAndEnqueue, this.pool);
 
     return { run, created };
   }
@@ -1315,11 +1309,10 @@ export class WorkflowEngine {
   // and can never overwrite a status another worker just wrote (e.g. a
   // concurrent invoke-completion event flipping the parent to COMPLETED).
   //
-  // The child enqueue is intentionally moved OUT of the transaction so we don't
-  // dispatch a child job that could race the parent's commit. This mirrors the
-  // post-commit + revert-on-failure pattern used by waitStep/pollStep; the
-  // re-send semantics are still safe because the existingInvoke branch detects
-  // the already-created child on retry and re-pauses without re-creating it.
+  // The child run insert AND its pgboss.job enqueue both join this same
+  // transaction. The parent pause, child run row, and child job all commit (or
+  // roll back) together, so a worker crashing between "parent paused" and
+  // "child enqueued" is impossible — there is no such interleaving window.
   private async invokeChildWorkflowStep({
     run,
     stepId,
@@ -1339,8 +1332,6 @@ export class WorkflowEngine {
   }): Promise<unknown> {
     let invokeOutput: unknown;
     let hasInvokeOutput = false;
-    let childRunToEnqueue: WorkflowRun | undefined;
-    let parentRunForRevert: WorkflowRun = run;
     const childResourceId = resourceId ?? run.resourceId ?? undefined;
     const childIdempotencyKey = idempotencyKey;
 
@@ -1351,8 +1342,12 @@ export class WorkflowEngine {
           { runId: run.id, resourceId: run.resourceId ?? undefined },
           { exclusiveLock: true, db },
         );
-        parentRunForRevert = lockedRun;
 
+        // If the parent isn't RUNNING, fall through and return `undefined`. The
+        // worker's outer loop won't act on it: subsequent `step.run` calls
+        // short-circuit the same way (see `runStep`), and the post-handler
+        // `shouldComplete` check requires `status === RUNNING` so no terminal
+        // state is written. Matches the pattern used by the other step kinds.
         if (
           lockedRun.status === WorkflowStatus.CANCELLED ||
           lockedRun.status === WorkflowStatus.PAUSED ||
@@ -1408,6 +1403,10 @@ export class WorkflowEngine {
             this.throwForNonCompletedChild(existingChildRun);
           }
 
+          // Child is still RUNNING/PAUSED. The original enqueue committed
+          // with the prior parent-pause txn, so pg-boss already owns the
+          // child job — re-pause the parent and wait for the next terminal
+          // event without re-enqueueing.
           await this.pauseRunForWait({
             run: lockedRun,
             stepId,
@@ -1415,7 +1414,6 @@ export class WorkflowEngine {
             skipOutput: true,
             db,
           });
-          childRunToEnqueue = existingChildRun;
           return;
         }
 
@@ -1428,7 +1426,7 @@ export class WorkflowEngine {
           parentRunId: run.id,
           parentStepId: stepId,
           parentResourceId: run.resourceId ?? undefined,
-          enqueue: false,
+          enqueue: true,
           db,
         });
         const childRun = result.run;
@@ -1498,71 +1496,12 @@ export class WorkflowEngine {
             },
           }),
         });
-
-        childRunToEnqueue = childRun;
       },
       this.pool,
     );
 
     if (hasInvokeOutput) {
       return invokeOutput;
-    }
-
-    if (childRunToEnqueue) {
-      await this.enqueueChildWorkflowAfterParentWaitCommits({
-        parentRun: parentRunForRevert,
-        childRun: childRunToEnqueue,
-        options,
-      });
-    }
-  }
-
-  // Dispatch the child only after the parent's invoke wait is durable. If this
-  // send fails, the parent is made RUNNING again so the step can retry and
-  // re-enqueue the already-created child run.
-  private async enqueueChildWorkflowAfterParentWaitCommits({
-    parentRun,
-    childRun,
-    options,
-  }: {
-    parentRun: WorkflowRun;
-    childRun: WorkflowRun;
-    options?: WorkflowRunOptions;
-  }) {
-    try {
-      await this.enqueueWorkflowRun(childRun, options);
-    } catch (error) {
-      // Only flip back to RUNNING if the parent is still PAUSED. Anything else
-      // (e.g. the parent was cancelled while we were trying to enqueue the
-      // child, or a duplicate notify already woke it) means our PAUSED row is
-      // gone and resurrecting the parent would orphan it without a job.
-      try {
-        await this.updateRun({
-          runId: parentRun.id,
-          resourceId: parentRun.resourceId ?? undefined,
-          data: {
-            status: WorkflowStatus.RUNNING,
-            pausedAt: null,
-          },
-          expectedStatuses: [WorkflowStatus.PAUSED],
-        });
-      } catch (revertError) {
-        // Swallow status-mismatch errors so we still surface the original
-        // enqueue failure as the cause; log everything else for visibility.
-        if (
-          !(
-            revertError instanceof WorkflowEngineError &&
-            revertError.message.includes('Cannot update workflow run')
-          )
-        ) {
-          this.logger.error(
-            'Failed to revert parent run after invoke enqueue failure',
-            revertError as Error,
-            { runId: parentRun.id, workflowId: parentRun.workflowId },
-          );
-        }
-      }
-      throw error;
     }
   }
 


### PR DESCRIPTION
## Summary
- Move the `step.invokeChildWorkflow()` child enqueue into the same transaction that pauses the parent, so both commit (or roll back) atomically.
- Drop the post-commit `enqueueChildWorkflowAfterParentWaitCommits` helper and the lockedInvoke re-enqueue path — neither is reachable under transactional enqueue.
- Annotate the non-RUNNING early-return inside `invokeChildWorkflowStep` to clarify it matches the existing `runStep` short-circuit (no terminal state is written; worker exits cleanly).

## Why
The previous flow paused the parent in one transaction and called `boss.send` for the child afterward. A worker crash (or any pg-boss-side failure) in that window left the parent PAUSED with no child job. DLQ recovery (introduced in #29) only acts on `status === RUNNING`, so the parent could never be unstuck. Joining the child enqueue to the parent-pause transaction removes the interleaving window entirely.

## Test plan
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test:unit` — 120 passed (1 skipped, 1 todo)
- Replaced "should enqueue child workflow only after parent invoke wait is committed" — its premise (post-commit ordering) no longer matches the implementation. The atomic-commit invariant is now covered by the rollback-on-enqueue-failure test below.
- Tightened "should retry cleanly when child enqueue fails after parent pause is prepared" → "should roll back the entire invoke txn when child enqueue fails and recreate a fresh child on retry": same scenario, verifies the new rollback semantics (no orphan child rows transiently committed).
- [ ] Manual smoke test against a real Postgres (run `npm run test:integration` if a DB is available)