### PR TITLE
feat: workflows flow control - concurrency & singleton

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -36,7 +36,7 @@ When `boss` is omitted, pg-boss is created automatically with an isolated schema
 | `stop()` | Stop the engine gracefully |
 | `registerWorkflow(definition)` | Register a workflow definition |
 | `startWorkflow(ref, input, options?)` | Start a top-level workflow run using a typed ref (see [WorkflowRef](#workflowref)) |
-| `startWorkflow({ workflowId, resourceId?, input, idempotencyKey?, options? })` | Start a top-level workflow run by ID. `resourceId` optionally ties the run to an external entity (see [Resource ID](core-concepts.md#resource-id)). `idempotencyKey` optionally deduplicates starts (see [Idempotency Key](core-concepts.md#idempotency-key)). |
+| `startWorkflow({ workflowId, resourceId?, input, idempotencyKey?, options? })` | Start a top-level workflow run by ID. `resourceId` optionally ties the run to an external entity (see [Resource ID](core-concepts.md#resource-id)). `idempotencyKey` optionally deduplicates starts (see [Idempotency Key](core-concepts.md#idempotency-key)). This overload is flow-control aware when the engine has the registered workflow definition. |
 | `pauseWorkflow({ runId, resourceId? })` | Pause a running workflow |
 | `resumeWorkflow({ runId, resourceId?, options? })` | Resume a paused workflow. No-ops for `step.invokeChildWorkflow()` waits. |
 | `cancelWorkflow({ runId, resourceId? })` | Cancel a workflow |
@@ -67,8 +67,8 @@ const client = new WorkflowClient({
 |--------|-------------|
 | `start()` | Connect to the database (called automatically on first use) |
 | `stop()` | Close the connection |
-| `startWorkflow(ref, input, options?)` | Start a top-level workflow run using a typed ref |
-| `startWorkflow({ workflowId, input, resourceId?, options? })` | Start a top-level workflow run by ID |
+| `startWorkflow(ref, input, options?)` | Start a top-level workflow run using a typed ref. Ref-based starts support `flowControl` because the ref carries the resolver. |
+| `startWorkflow({ workflowId, input, resourceId?, options? })` | Start a top-level workflow run by ID. This raw overload does not evaluate callback-based `flowControl`. |
 | `pauseWorkflow({ runId, resourceId? })` | Pause a running workflow |
 | `resumeWorkflow({ runId, resourceId?, options? })` | Resume a paused workflow. No-ops for `step.invokeChildWorkflow()` waits. |
 | `cancelWorkflow({ runId, resourceId? })` | Cancel a workflow |
@@ -89,6 +89,12 @@ import { z } from 'zod'
 // Create a ref — just an ID + schema, no handler
 const myWorkflow = createWorkflowRef('my-workflow', {
   inputSchema: z.object({ email: z.string().email() }),
+  flowControl: {
+    concurrency: (input) => ({
+      key: input.email,
+      limit: 1,
+    }),
+  },
 })
 
 // Use in API service — type-safe input
@@ -112,6 +118,8 @@ const output = await step.invokeChildWorkflow('call-child', childWorkflow, {})
 // output is ChildOutput
 ```
 
+`flowControl` on a ref is shared metadata used by `WorkflowClient.startWorkflow(ref, ...)` and by engine-side starts.
+
 ## workflow()
 
 ```typescript
@@ -122,9 +130,15 @@ workflow<I extends Parameters>(
     inputSchema?: I,
     timeout?: number,
     retries?: number,
+    flowControl?: {
+      concurrency?: (input: InferInputParameters<I>) => { key: string; limit: number },
+      singleton?: (input: InferInputParameters<I>) => { key: string; mode: 'skip' | 'cancel' },
+    },
   }
 ): WorkflowDefinition<I>
 ```
+
+`concurrency` and `singleton` are mutually exclusive. Use a constant concurrency key for workflow-wide limits.
 
 ## WorkflowContext
 
@@ -173,3 +187,10 @@ enum WorkflowStatus {
   CANCELLED = 'cancelled',
 }
 ```
+
+## WorkflowRun
+
+`getRun()`, `getRuns()`, and `startWorkflow()` return a `WorkflowRun` that includes:
+
+- `concurrencyKey: string | null` — the resolved key from `flowControl`, if any
+- `pauseReason: string | null` — internal pause classification used to decide how a paused run should re-enter execution

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -75,12 +75,20 @@ import { z } from 'zod'
 
 export const onboardUser = createWorkflowRef('onboard-user', {
   inputSchema: z.object({ email: z.string().email() }),
+  flowControl: {
+    concurrency: (input) => ({
+      key: input.email,
+      limit: 1,
+    }),
+  },
 })
 
 export const processPayment = createWorkflowRef('process-payment', {
   inputSchema: z.object({ orderId: z.string(), amount: z.number() }),
 })
 ```
+
+If your API service needs `flowControl` (`concurrency` or `singleton`), put it on the shared ref. The raw client overload `startWorkflow({ workflowId, input })` cannot evaluate callback-based flow-control resolvers because it only knows the workflow ID.
 
 ### Step 2: API service — uses lightweight client, no handler code
 

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -168,6 +168,102 @@ const again = await engine.startWorkflow({
 
 The returned `WorkflowRun` includes `idempotencyKey` (or `null` if omitted).
 
+## Flow Control
+
+Workflow definitions can opt into flow control with `flowControl`. v1 supports two mutually exclusive modes:
+
+- `concurrency` limits how many runs for a derived key may actively execute at the same time
+- `singleton` ensures only one non-terminal run exists for a derived key
+
+```typescript
+const syncAccount = workflow(
+  'sync-account',
+  async ({ step, input }) => {
+    return await step.run('sync', async () => {
+      return await syncExternalAccount(input.accountId)
+    })
+  },
+  {
+    inputSchema: z.object({
+      accountId: z.string(),
+      tenantId: z.string(),
+    }),
+    flowControl: {
+      concurrency: (input) => ({
+        key: input.tenantId,
+        limit: 5,
+      }),
+    },
+  },
+)
+```
+
+### Concurrency
+
+Concurrency only counts runs while they are actively executing in `running`. If the limit for a key is full, new runs are inserted as `pending` and promoted later when a slot opens.
+
+- Leaving `running` releases capacity immediately, including transitions to `paused`
+- Pending promotion is FIFO by `created_at`, but one blocked key does not prevent other keys from being promoted
+- To create workflow-wide concurrency, return a constant key such as `() => ({ key: '__workflow__', limit: 10 })`
+
+The returned `WorkflowRun` includes the resolved `concurrencyKey`, or `null` when no flow control is configured.
+
+### Singleton
+
+Singleton governs the whole run, not just active execution. It treats `pending`, `running`, and `paused` runs as conflicting for the same `(workflowId, key)`.
+
+```typescript
+const sendDigest = workflow(
+  'send-digest',
+  async ({ step, input }) => {
+    return await step.run('send', async () => {
+      return await emailDigest(input.userId)
+    })
+  },
+  {
+    inputSchema: z.object({ userId: z.string() }),
+    flowControl: {
+      singleton: (input) => ({
+        key: input.userId,
+        mode: 'skip',
+      }),
+    },
+  },
+)
+```
+
+- `mode: 'skip'` returns the oldest conflicting non-terminal run and does not create a new one
+- `mode: 'cancel'` cancels existing conflicting runs for the key, then creates the new run
+
+### Flow Control vs Idempotency
+
+`idempotencyKey` and `flowControl` solve different problems:
+
+- `idempotencyKey` is global deduplication for repeated start requests and returns the exact same stored run forever
+- `concurrency` queues excess runs until capacity is available
+- `singleton` controls whether keyed runs are skipped or replaced while an older run is still in progress
+
+If both are used, idempotency is evaluated first.
+
+### Client Limitation
+
+Callback-based flow control is available when starting workflows from a shared `WorkflowRef` because the ref carries the resolver:
+
+```typescript
+await client.startWorkflow(myWorkflowRef, { tenantId: 't_123' })
+```
+
+The raw client overload does not evaluate `flowControl` callbacks because it only knows the workflow ID:
+
+```typescript
+await client.startWorkflow({
+  workflowId: 'sync-account',
+  input: { tenantId: 't_123' },
+})
+```
+
+In microservice setups, share `WorkflowRef`s between API and worker services if you need flow control outside the engine process.
+
 ## Pause and Resume
 
 Manually pause a workflow and resume it later:

--- a/package-lock.json
+++ b/package-lock.json
@@ -297,31 +297,6 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -329,7 +304,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -2226,6 +2200,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -2340,6 +2315,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2641,6 +2617,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2677,6 +2654,7 @@
       "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",

--- a/src/client.entry.ts
+++ b/src/client.entry.ts
@@ -5,8 +5,10 @@ export { createWorkflowRef } from './definition';
 export type {
   InferInputParameters,
   InputParameters,
+  WorkflowFlowControl,
   WorkflowLogger,
   WorkflowRef,
+  WorkflowRefOptions,
   WorkflowRunProgress,
 } from './types';
 export { WorkflowStatus } from './types';

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -21,6 +21,20 @@ const testRef = createWorkflowRef('test-client-workflow', {
   inputSchema: z.object({ data: z.string() }),
 });
 
+const concurrencyRef = createWorkflowRef('client-flow-concurrency', {
+  inputSchema: z.object({ group: z.string() }),
+  flowControl: {
+    concurrency: (input) => ({ key: input.group, limit: 1 }),
+  },
+});
+
+const singletonRef = createWorkflowRef('client-flow-singleton', {
+  inputSchema: z.object({ userId: z.string() }),
+  flowControl: {
+    singleton: (input) => ({ key: input.userId, mode: 'skip' }),
+  },
+});
+
 describe('WorkflowClient', () => {
   const resourceId = 'testResourceId';
   let client: WorkflowClient;
@@ -134,6 +148,47 @@ describe('WorkflowClient', () => {
       expect(schemas.rows).toHaveLength(1);
 
       await customClient.stop();
+    });
+  });
+
+  describe('flow control', () => {
+    it('applies ref-based concurrency and queues the second run', async () => {
+      const run1 = await client.startWorkflow(concurrencyRef, { group: 'team-a' }, { resourceId });
+      const run2 = await client.startWorkflow(concurrencyRef, { group: 'team-a' }, { resourceId });
+
+      expect(run1.id).not.toBe(run2.id);
+      expect(run1.status).toBe(WorkflowStatus.RUNNING);
+      expect(run2.status).toBe(WorkflowStatus.PENDING);
+      expect(run1.concurrencyKey).toBe('team-a');
+      expect(run2.concurrencyKey).toBe('team-a');
+    });
+
+    it('applies ref-based singleton skip and returns the existing run', async () => {
+      const run1 = await client.startWorkflow(singletonRef, { userId: 'user-1' }, { resourceId });
+      const run2 = await client.startWorkflow(singletonRef, { userId: 'user-1' }, { resourceId });
+
+      expect(run1.id).toBe(run2.id);
+      expect(run1.concurrencyKey).toBe('user-1');
+    });
+
+    it('does not apply callback-based flow control to raw object starts', async () => {
+      const run1 = await client.startWorkflow({
+        resourceId,
+        workflowId: 'client-flow-concurrency',
+        input: { group: 'team-a' },
+      });
+
+      const run2 = await client.startWorkflow({
+        resourceId,
+        workflowId: 'client-flow-concurrency',
+        input: { group: 'team-a' },
+      });
+
+      expect(run1.id).not.toBe(run2.id);
+      expect(run1.status).toBe(WorkflowStatus.RUNNING);
+      expect(run2.status).toBe(WorkflowStatus.RUNNING);
+      expect(run1.concurrencyKey).toBeNull();
+      expect(run2.concurrencyKey).toBeNull();
     });
   });
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -11,19 +11,27 @@ import {
 } from './constants';
 import { runMigrations } from './db/migration';
 import {
+  acquireIdempotencyKeyLock,
+  acquireWorkflowAdmissionLock,
+  cancelConflictingSingletonRuns,
+  countRunningWorkflowRunsByConcurrencyKey,
+  findOldestConflictingSingletonRun,
+  getPendingWorkflowRunsByWorkflowId,
   getWorkflowRun,
+  getWorkflowRunByIdempotencyKey,
   getWorkflowRuns,
   insertWorkflowRun,
   updateWorkflowRun,
   withPostgresTransaction,
 } from './db/queries';
-import type { WorkflowRun } from './db/types';
+import type { PersistedWorkflowRun, WorkflowRun } from './db/types';
 import {
   validateResourceId,
   validateWorkflowId,
   WorkflowEngineError,
   WorkflowRunNotFoundError,
 } from './error';
+import { type ResolvedFlowControl, resolveFlowControl } from './flow-control';
 import {
   type InferInputParameters,
   type InputParameters,
@@ -68,6 +76,8 @@ const defaultLogger: WorkflowLogger = {
 const defaultExpireInSeconds = process.env.WORKFLOW_RUN_EXPIRE_IN_SECONDS
   ? Number.parseInt(process.env.WORKFLOW_RUN_EXPIRE_IN_SECONDS, 10)
   : 5 * 60;
+
+const PAUSE_REASON_MANUAL = 'manual';
 
 export class WorkflowClient {
   private boss: PgBoss;
@@ -127,6 +137,100 @@ export class WorkflowClient {
     this.logger.log(`${LOG_PREFIX} Client stopped`);
   }
 
+  private async enqueueWorkflowRun(
+    run: PersistedWorkflowRun,
+    options?: { expireInSeconds?: number },
+    db?: Db,
+  ) {
+    const job: WorkflowRunJobParameters = {
+      runId: run.id,
+      resourceId: run.resourceId ?? undefined,
+      workflowId: run.workflowId,
+      input: run.input,
+    };
+
+    await this.boss.send(WORKFLOW_RUN_QUEUE_NAME, job, {
+      startAfter: new Date(),
+      expireInSeconds: options?.expireInSeconds ?? defaultExpireInSeconds,
+      db,
+    });
+  }
+
+  private async promotePendingRuns(
+    workflowId: string,
+    options?: { expireInSeconds?: number },
+  ): Promise<void> {
+    await withPostgresTransaction(
+      this.db,
+      async (db) => {
+        await acquireWorkflowAdmissionLock(workflowId, db);
+
+        const pendingRuns = await getPendingWorkflowRunsByWorkflowId(workflowId, db);
+        const runningCounts = new Map<string, number>();
+
+        for (const pendingRun of pendingRuns) {
+          if (!pendingRun.concurrencyKey || !pendingRun.concurrencyLimit) {
+            const promoted = await updateWorkflowRun(
+              {
+                runId: pendingRun.id,
+                resourceId: pendingRun.resourceId ?? undefined,
+                data: {
+                  status: WorkflowStatus.RUNNING,
+                  pausedAt: null,
+                  pauseReason: null,
+                },
+                expectedStatuses: [WorkflowStatus.PENDING],
+              },
+              db,
+            );
+
+            if (promoted) {
+              await this.enqueueWorkflowRun(promoted, options, db);
+            }
+            continue;
+          }
+
+          const currentCount =
+            runningCounts.get(pendingRun.concurrencyKey) ??
+            (await countRunningWorkflowRunsByConcurrencyKey(
+              {
+                workflowId,
+                concurrencyKey: pendingRun.concurrencyKey,
+              },
+              db,
+            ));
+
+          if (currentCount >= pendingRun.concurrencyLimit) {
+            runningCounts.set(pendingRun.concurrencyKey, currentCount);
+            continue;
+          }
+
+          const promoted = await updateWorkflowRun(
+            {
+              runId: pendingRun.id,
+              resourceId: pendingRun.resourceId ?? undefined,
+              data: {
+                status: WorkflowStatus.RUNNING,
+                pausedAt: null,
+                pauseReason: null,
+              },
+              expectedStatuses: [WorkflowStatus.PENDING],
+            },
+            db,
+          );
+
+          if (!promoted) {
+            continue;
+          }
+
+          runningCounts.set(pendingRun.concurrencyKey, currentCount + 1);
+          await this.enqueueWorkflowRun(promoted, options, db);
+        }
+      },
+      this.pool,
+    );
+  }
+
   async startWorkflow<TInput extends InputParameters>(
     ref: WorkflowRef<TInput>,
     input: InferInputParameters<TInput>,
@@ -161,6 +265,7 @@ export class WorkflowClient {
     let resourceId: string | undefined;
     let idempotencyKey: string | undefined;
     let options: StartWorkflowOptions | undefined;
+    let resolvedFlowControl: ResolvedFlowControl | null = null;
 
     if (typeof refOrParams === 'function' && 'id' in refOrParams) {
       const ref = refOrParams as WorkflowRef<TInput>;
@@ -182,6 +287,11 @@ export class WorkflowClient {
           );
         }
       }
+
+      resolvedFlowControl = resolveFlowControl(
+        ref.flowControl,
+        inputArg as InferInputParameters<TInput>,
+      );
     } else {
       const params = refOrParams as {
         workflowId: string;
@@ -205,37 +315,76 @@ export class WorkflowClient {
       async (_db) => {
         const timeoutAt = options?.timeout ? new Date(Date.now() + options.timeout) : null;
 
+        if (idempotencyKey) {
+          await acquireIdempotencyKeyLock(idempotencyKey, _db);
+          const existingByIdempotency = await getWorkflowRunByIdempotencyKey(idempotencyKey, _db);
+          if (existingByIdempotency) {
+            return existingByIdempotency;
+          }
+        }
+
+        await acquireWorkflowAdmissionLock(workflowId, _db);
+
+        if (resolvedFlowControl?.type === 'singleton') {
+          const existingSingleton = await findOldestConflictingSingletonRun(
+            {
+              workflowId,
+              concurrencyKey: resolvedFlowControl.concurrencyKey,
+            },
+            _db,
+          );
+
+          if (existingSingleton) {
+            if (resolvedFlowControl.singletonMode === 'skip') {
+              return existingSingleton;
+            }
+
+            await cancelConflictingSingletonRuns(
+              {
+                workflowId,
+                concurrencyKey: resolvedFlowControl.concurrencyKey,
+              },
+              _db,
+            );
+          }
+        }
+
+        const isConcurrencyLimited = resolvedFlowControl?.type === 'concurrency';
+        const status =
+          isConcurrencyLimited &&
+          (await countRunningWorkflowRunsByConcurrencyKey(
+            {
+              workflowId,
+              concurrencyKey: resolvedFlowControl.concurrencyKey,
+            },
+            _db,
+          )) >= resolvedFlowControl.concurrencyLimit
+            ? WorkflowStatus.PENDING
+            : WorkflowStatus.RUNNING;
+
         const { run: insertedRun, created } = await insertWorkflowRun(
           {
             resourceId,
             workflowId,
             currentStepId: '__start__',
-            status: WorkflowStatus.RUNNING,
+            status,
             input,
             maxRetries: options?.retries ?? 0,
             timeoutAt,
             idempotencyKey,
+            concurrencyKey: resolvedFlowControl?.concurrencyKey ?? null,
+            concurrencyLimit:
+              resolvedFlowControl?.type === 'concurrency'
+                ? resolvedFlowControl.concurrencyLimit
+                : null,
+            singletonMode:
+              resolvedFlowControl?.type === 'singleton' ? resolvedFlowControl.singletonMode : null,
           },
           _db,
         );
 
-        if (created) {
-          const job: WorkflowRunJobParameters = {
-            runId: insertedRun.id,
-            resourceId,
-            workflowId,
-            input,
-          };
-
-          // Same connection (`_db`) used for the workflow_runs INSERT is passed
-          // to `boss.send` so the pgboss.job INSERT joins the same transaction.
-          // The two writes commit or roll back together, so we never leak an
-          // orphan workflow_runs row when the queue insert fails.
-          await this.boss.send(WORKFLOW_RUN_QUEUE_NAME, job, {
-            startAfter: new Date(),
-            expireInSeconds: options?.expireInSeconds ?? defaultExpireInSeconds,
-            db: _db,
-          });
+        if (created && insertedRun.status === WorkflowStatus.RUNNING) {
+          await this.enqueueWorkflowRun(insertedRun, options, _db);
         }
 
         return insertedRun;
@@ -300,6 +449,7 @@ export class WorkflowClient {
         data: {
           status: WorkflowStatus.PAUSED,
           pausedAt: new Date(),
+          pauseReason: PAUSE_REASON_MANUAL,
         },
         expectedStatuses: [WorkflowStatus.RUNNING, WorkflowStatus.PENDING],
       },
@@ -309,6 +459,8 @@ export class WorkflowClient {
     if (!run) {
       throw new WorkflowRunNotFoundError(runId);
     }
+
+    await this.promotePendingRuns(run.workflowId);
 
     this.logger.log(`${LOG_PREFIX} Paused workflow run ${runId}`);
     return run;
@@ -444,6 +596,7 @@ export class WorkflowClient {
         resourceId,
         data: {
           status: WorkflowStatus.CANCELLED,
+          pauseReason: null,
         },
         expectedStatuses: [WorkflowStatus.PENDING, WorkflowStatus.RUNNING, WorkflowStatus.PAUSED],
       },
@@ -453,6 +606,8 @@ export class WorkflowClient {
     if (!run) {
       throw new WorkflowRunNotFoundError(runId);
     }
+
+    await this.promotePendingRuns(run.workflowId);
 
     this.logger.log(`${LOG_PREFIX} Cancelled workflow run ${runId}`);
     return run;

--- a/src/db/migration.ts
+++ b/src/db/migration.ts
@@ -5,7 +5,7 @@ export const MIGRATION_LOCK_ID = 738291645;
 
 // Bump this when adding new migrations. The engine stores the current version
 // in a `workflow_schema_version` table so migrations only run once per version.
-const CURRENT_SCHEMA_VERSION = 4;
+const CURRENT_SCHEMA_VERSION = 5;
 
 export async function runMigrations(db: Db): Promise<void> {
   // Fast path: skip the advisory lock if schema is already current.
@@ -85,6 +85,32 @@ export async function runMigrations(db: Db): Promise<void> {
     commands.push(
       'ALTER TABLE workflow_runs ADD COLUMN IF NOT EXISTS parent_resource_id varchar(256)',
     );
+  }
+
+  if (currentVersion < 5) {
+    commands.push(
+      'ALTER TABLE workflow_runs ADD COLUMN IF NOT EXISTS concurrency_key varchar(256)',
+    );
+    commands.push('ALTER TABLE workflow_runs ADD COLUMN IF NOT EXISTS concurrency_limit integer');
+    commands.push('ALTER TABLE workflow_runs ADD COLUMN IF NOT EXISTS singleton_mode text');
+    commands.push('ALTER TABLE workflow_runs ADD COLUMN IF NOT EXISTS pause_reason text');
+    commands.push(`
+      CREATE INDEX IF NOT EXISTS workflow_runs_workflow_id_pending_created_at_idx
+      ON workflow_runs USING btree (workflow_id, created_at ASC)
+      WHERE status = 'pending'
+    `);
+    commands.push(`
+      CREATE INDEX IF NOT EXISTS workflow_runs_workflow_id_concurrency_key_running_idx
+      ON workflow_runs USING btree (workflow_id, concurrency_key, created_at ASC)
+      WHERE status = 'running' AND concurrency_key IS NOT NULL
+    `);
+    commands.push(`
+      CREATE INDEX IF NOT EXISTS workflow_runs_singleton_lookup_idx
+      ON workflow_runs USING btree (workflow_id, concurrency_key, created_at ASC)
+      WHERE parent_run_id IS NULL
+        AND concurrency_key IS NOT NULL
+        AND status IN ('pending', 'running', 'paused')
+    `);
   }
 
   // Upsert the schema version

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -1,6 +1,6 @@
 import ksuid from 'ksuid';
 import type { Db } from 'pg-boss';
-import type { WorkflowRun } from './types';
+import type { PersistedWorkflowRun, WorkflowRun } from './types';
 
 export function generateKSUID(prefix?: string): string {
   return `${prefix ? `${prefix}_` : ''}${ksuid.randomSync().string}`;
@@ -26,12 +26,16 @@ type WorkflowRunRow = {
   max_retries: number;
   job_id: string | null;
   idempotency_key: string | null;
+  concurrency_key: string | null;
+  concurrency_limit: number | null;
+  singleton_mode: 'skip' | 'cancel' | null;
+  pause_reason: string | null;
   parent_run_id: string | null;
   parent_step_id: string | null;
   parent_resource_id: string | null;
 };
 
-function mapRowToWorkflowRun(row: WorkflowRunRow): WorkflowRun {
+function mapRowToWorkflowRun(row: WorkflowRunRow): PersistedWorkflowRun {
   return {
     id: row.id,
     createdAt: new Date(row.created_at),
@@ -57,6 +61,10 @@ function mapRowToWorkflowRun(row: WorkflowRunRow): WorkflowRun {
     maxRetries: row.max_retries,
     jobId: row.job_id,
     idempotencyKey: row.idempotency_key,
+    concurrencyKey: row.concurrency_key,
+    concurrencyLimit: row.concurrency_limit,
+    singletonMode: row.singleton_mode,
+    pauseReason: row.pause_reason,
     parentRunId: row.parent_run_id,
     parentStepId: row.parent_step_id,
     parentResourceId: row.parent_resource_id,
@@ -73,6 +81,10 @@ export async function insertWorkflowRun(
     maxRetries,
     timeoutAt,
     idempotencyKey,
+    concurrencyKey,
+    concurrencyLimit,
+    singletonMode,
+    pauseReason,
     parentRunId,
     parentStepId,
     parentResourceId,
@@ -85,6 +97,10 @@ export async function insertWorkflowRun(
     maxRetries: number;
     timeoutAt: Date | null;
     idempotencyKey?: string;
+    concurrencyKey?: string | null;
+    concurrencyLimit?: number | null;
+    singletonMode?: 'skip' | 'cancel' | null;
+    pauseReason?: string | null;
     parentRunId?: string;
     parentStepId?: string;
     parentResourceId?: string;
@@ -109,11 +125,15 @@ export async function insertWorkflowRun(
       timeline,
       retry_count,
       idempotency_key,
+      concurrency_key,
+      concurrency_limit,
+      singleton_mode,
+      pause_reason,
       parent_run_id,
       parent_step_id,
       parent_resource_id
     )
-    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)
     ON CONFLICT (idempotency_key) WHERE idempotency_key IS NOT NULL DO NOTHING
     RETURNING *`,
     [
@@ -130,6 +150,10 @@ export async function insertWorkflowRun(
       '{}',
       0,
       idempotencyKey ?? null,
+      concurrencyKey ?? null,
+      concurrencyLimit ?? null,
+      singletonMode ?? null,
+      pauseReason ?? null,
       parentRunId ?? null,
       parentStepId ?? null,
       parentResourceId ?? null,
@@ -161,7 +185,7 @@ export async function getWorkflowRun(
     resourceId?: string;
   },
   { exclusiveLock = false, db }: { exclusiveLock?: boolean; db: Db },
-): Promise<WorkflowRun | null> {
+): Promise<PersistedWorkflowRun | null> {
   const lockSuffix = exclusiveLock ? 'FOR UPDATE' : '';
 
   const result = resourceId
@@ -196,11 +220,11 @@ export async function updateWorkflowRun(
   }: {
     runId: string;
     resourceId?: string;
-    data: Partial<WorkflowRun>;
+    data: Partial<PersistedWorkflowRun>;
     expectedStatuses?: string[];
   },
   db: Db,
-): Promise<WorkflowRun | null> {
+): Promise<PersistedWorkflowRun | null> {
   const now = new Date();
 
   const updates: string[] = ['updated_at = $1'];
@@ -255,6 +279,26 @@ export async function updateWorkflowRun(
   if (data.jobId !== undefined) {
     updates.push(`job_id = $${paramIndex}`);
     values.push(data.jobId);
+    paramIndex++;
+  }
+  if (data.concurrencyKey !== undefined) {
+    updates.push(`concurrency_key = $${paramIndex}`);
+    values.push(data.concurrencyKey);
+    paramIndex++;
+  }
+  if (data.concurrencyLimit !== undefined) {
+    updates.push(`concurrency_limit = $${paramIndex}`);
+    values.push(data.concurrencyLimit);
+    paramIndex++;
+  }
+  if (data.singletonMode !== undefined) {
+    updates.push(`singleton_mode = $${paramIndex}`);
+    values.push(data.singletonMode);
+    paramIndex++;
+  }
+  if (data.pauseReason !== undefined) {
+    updates.push(`pause_reason = $${paramIndex}`);
+    values.push(data.pauseReason);
     paramIndex++;
   }
 
@@ -315,7 +359,7 @@ export async function getWorkflowRuns(
   },
   db: Db,
 ): Promise<{
-  items: WorkflowRun[];
+  items: PersistedWorkflowRun[];
   nextCursor: string | null;
   prevCursor: string | null;
   hasMore: boolean;
@@ -408,6 +452,105 @@ export async function getWorkflowRuns(
   const prevCursor = hasPrev && items.length > 0 ? (items[0]?.id ?? null) : null;
 
   return { items, nextCursor, prevCursor, hasMore, hasPrev };
+}
+
+export async function getWorkflowRunByIdempotencyKey(
+  idempotencyKey: string,
+  db: Db,
+): Promise<PersistedWorkflowRun | null> {
+  const result = await db.executeSql('SELECT * FROM workflow_runs WHERE idempotency_key = $1', [
+    idempotencyKey,
+  ]);
+
+  return result.rows[0] ? mapRowToWorkflowRun(result.rows[0]) : null;
+}
+
+function hashLockKey(value: string): number {
+  let hash = 2166136261;
+
+  for (let i = 0; i < value.length; i++) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+
+  return hash | 0;
+}
+
+export async function acquireWorkflowAdmissionLock(workflowId: string, db: Db): Promise<void> {
+  await db.executeSql('SELECT pg_advisory_xact_lock($1, $2)', [9182, hashLockKey(workflowId)]);
+}
+
+export async function acquireIdempotencyKeyLock(idempotencyKey: string, db: Db): Promise<void> {
+  await db.executeSql('SELECT pg_advisory_xact_lock($1, $2)', [9183, hashLockKey(idempotencyKey)]);
+}
+
+export async function countRunningWorkflowRunsByConcurrencyKey(
+  { workflowId, concurrencyKey }: { workflowId: string; concurrencyKey: string },
+  db: Db,
+): Promise<number> {
+  const result = await db.executeSql(
+    `SELECT COUNT(*)::int AS count
+     FROM workflow_runs
+     WHERE workflow_id = $1
+       AND status = 'running'
+       AND concurrency_key = $2`,
+    [workflowId, concurrencyKey],
+  );
+
+  return ((result.rows[0] as { count: number } | undefined)?.count ?? 0) as number;
+}
+
+export async function findOldestConflictingSingletonRun(
+  { workflowId, concurrencyKey }: { workflowId: string; concurrencyKey: string },
+  db: Db,
+): Promise<PersistedWorkflowRun | null> {
+  const result = await db.executeSql(
+    `SELECT *
+     FROM workflow_runs
+     WHERE workflow_id = $1
+       AND concurrency_key = $2
+       AND parent_run_id IS NULL
+       AND status = ANY($3)
+     ORDER BY created_at ASC
+     LIMIT 1`,
+    [workflowId, concurrencyKey, ['pending', 'running', 'paused']],
+  );
+
+  return result.rows[0] ? mapRowToWorkflowRun(result.rows[0]) : null;
+}
+
+export async function cancelConflictingSingletonRuns(
+  { workflowId, concurrencyKey }: { workflowId: string; concurrencyKey: string },
+  db: Db,
+): Promise<PersistedWorkflowRun[]> {
+  const result = await db.executeSql(
+    `UPDATE workflow_runs
+     SET status = 'cancelled', updated_at = $3, pause_reason = NULL
+     WHERE workflow_id = $1
+       AND concurrency_key = $2
+       AND parent_run_id IS NULL
+       AND status = ANY($4)
+     RETURNING *`,
+    [workflowId, concurrencyKey, new Date(), ['pending', 'running', 'paused']],
+  );
+
+  return result.rows.map((row) => mapRowToWorkflowRun(row));
+}
+
+export async function getPendingWorkflowRunsByWorkflowId(
+  workflowId: string,
+  db: Db,
+): Promise<PersistedWorkflowRun[]> {
+  const result = await db.executeSql(
+    `SELECT *
+     FROM workflow_runs
+     WHERE workflow_id = $1
+       AND status = 'pending'
+     ORDER BY created_at ASC`,
+    [workflowId],
+  );
+
+  return result.rows.map((row) => mapRowToWorkflowRun(row));
 }
 
 /**

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -18,7 +18,14 @@ export type WorkflowRun = {
   maxRetries: number;
   jobId: string | null;
   idempotencyKey: string | null;
+  concurrencyKey: string | null;
+  pauseReason: string | null;
   parentRunId: string | null;
   parentStepId: string | null;
   parentResourceId: string | null;
+};
+
+export type PersistedWorkflowRun = WorkflowRun & {
+  concurrencyLimit: number | null;
+  singletonMode: 'skip' | 'cancel' | null;
 };

--- a/src/definition.test.ts
+++ b/src/definition.test.ts
@@ -1,6 +1,6 @@
-import { describe, expectTypeOf, it } from 'vitest';
+import { describe, expect, expectTypeOf, it } from 'vitest';
 import { z } from 'zod';
-import { workflow } from './definition';
+import { createWorkflowRef, workflow } from './definition';
 import type { StepBaseContext, WorkflowPlugin } from './types';
 
 describe('workflow definition type safety', () => {
@@ -127,6 +127,51 @@ describe('workflow definition type safety', () => {
         },
         { inputSchema: z.object({ action: z.enum(['create', 'delete']) }) },
       );
+    });
+  });
+
+  describe('flowControl', () => {
+    it('infers input type inside flowControl resolvers', () => {
+      workflow(
+        'flow-typed',
+        async () => {
+          return {};
+        },
+        {
+          inputSchema: z.object({ userId: z.string(), teamId: z.string().optional() }),
+          flowControl: {
+            concurrency: (input) => {
+              expectTypeOf(input.userId).toEqualTypeOf<string>();
+              expectTypeOf(input.teamId).toEqualTypeOf<string | undefined>();
+              return { key: input.userId, limit: 1 };
+            },
+          },
+        },
+      );
+    });
+
+    it('throws when concurrency and singleton are both defined on a workflow', () => {
+      expect(() =>
+        workflow('invalid-flow-control', async () => ({}), {
+          inputSchema: z.object({ userId: z.string() }),
+          flowControl: {
+            concurrency: (input) => ({ key: input.userId, limit: 1 }),
+            singleton: (input) => ({ key: input.userId, mode: 'skip' }),
+          },
+        }),
+      ).toThrow(/cannot define both/);
+    });
+
+    it('throws when concurrency and singleton are both defined on a workflow ref', () => {
+      expect(() =>
+        createWorkflowRef('invalid-flow-ref', {
+          inputSchema: z.object({ userId: z.string() }),
+          flowControl: {
+            concurrency: (input) => ({ key: input.userId, limit: 1 }),
+            singleton: (input) => ({ key: input.userId, mode: 'cancel' }),
+          },
+        }),
+      ).toThrow(/cannot define both/);
     });
   });
 });

--- a/src/definition.ts
+++ b/src/definition.ts
@@ -1,12 +1,15 @@
+import { assertValidFlowControl } from './flow-control';
 import type {
   InputParameters,
   StepBaseContext,
   WorkflowContext,
   WorkflowDefinition,
   WorkflowFactory,
+  WorkflowFlowControl,
   WorkflowOptions,
   WorkflowPlugin,
   WorkflowRef,
+  WorkflowRefOptions,
 } from './types';
 
 /**
@@ -16,16 +19,22 @@ import type {
 export function createWorkflowRef<
   TOutput = unknown,
   TInput extends InputParameters = InputParameters,
->(id: string, options?: { inputSchema?: TInput }): WorkflowRef<TInput, TOutput> {
+>(id: string, options?: WorkflowRefOptions<TInput>): WorkflowRef<TInput, TOutput> {
+  assertValidFlowControl(
+    options?.flowControl as WorkflowFlowControl | undefined,
+    `WorkflowRef "${id}"`,
+  );
+
   const ref = ((
     handler: (context: WorkflowContext<TInput, StepBaseContext>) => Promise<unknown>,
-    defineOptions?: Omit<WorkflowOptions<TInput>, 'inputSchema'>,
+    defineOptions?: Omit<WorkflowOptions<TInput>, 'inputSchema' | 'flowControl'>,
   ): WorkflowDefinition<TInput> => ({
     id,
     handler: handler as (
       context: WorkflowContext<InputParameters, StepBaseContext>,
     ) => Promise<unknown>,
     inputSchema: options?.inputSchema,
+    flowControl: options?.flowControl,
     timeout: defineOptions?.timeout,
     retries: defineOptions?.retries,
   })) as WorkflowRef<TInput, TOutput>;
@@ -33,6 +42,10 @@ export function createWorkflowRef<
   Object.defineProperty(ref, 'id', { value: id, enumerable: true });
   Object.defineProperty(ref, 'inputSchema', {
     value: options?.inputSchema,
+    enumerable: true,
+  });
+  Object.defineProperty(ref, 'flowControl', {
+    value: options?.flowControl,
     enumerable: true,
   });
 
@@ -45,19 +58,29 @@ function createWorkflowFactory<TStepExt extends object = object>(
   const factory = (<I extends InputParameters>(
     id: string,
     handler: (context: WorkflowContext<I, StepBaseContext & TStepExt>) => Promise<unknown>,
-    { inputSchema, timeout, retries }: WorkflowOptions<I> = {},
+    { inputSchema, timeout, retries, flowControl }: WorkflowOptions<I> = {},
   ): WorkflowDefinition<I> => ({
     id,
     handler: handler as (
       context: WorkflowContext<InputParameters, StepBaseContext>,
     ) => Promise<unknown>,
     inputSchema,
+    flowControl,
     timeout,
     retries,
     plugins: plugins.length > 0 ? (plugins as WorkflowPlugin[]) : undefined,
   })) as WorkflowFactory<TStepExt>;
 
-  factory.use = <TNewExt>(
+  const wrappedFactory = ((id, handler, options = {}) => {
+    assertValidFlowControl(
+      options.flowControl as WorkflowFlowControl | undefined,
+      `workflow("${id}")`,
+    );
+
+    return factory(id, handler, options);
+  }) as WorkflowFactory<TStepExt>;
+
+  wrappedFactory.use = <TNewExt>(
     plugin: WorkflowPlugin<StepBaseContext & TStepExt, TNewExt>,
   ): WorkflowFactory<TStepExt & TNewExt> =>
     createWorkflowFactory<TStepExt & TNewExt>([
@@ -65,9 +88,9 @@ function createWorkflowFactory<TStepExt extends object = object>(
       plugin as WorkflowPlugin<unknown, object>,
     ]);
 
-  factory.ref = createWorkflowRef;
+  wrappedFactory.ref = createWorkflowRef;
 
-  return factory;
+  return wrappedFactory;
 }
 
 export const workflow: WorkflowFactory = createWorkflowFactory();

--- a/src/engine.test.ts
+++ b/src/engine.test.ts
@@ -3,7 +3,11 @@ import type { PgBoss } from 'pg-boss';
 import * as v from 'valibot';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
-import { WORKFLOW_RUN_DLQ_QUEUE_NAME, WORKFLOW_RUN_QUEUE_NAME } from './constants';
+import {
+  WORKFLOW_RUN_DLQ_QUEUE_NAME,
+  WORKFLOW_RUN_QUEUE_NAME,
+  waitForTimelineKey,
+} from './constants';
 import type { WorkflowRun } from './db/types';
 import { workflow } from './definition';
 import { WorkflowEngine } from './engine';
@@ -3155,6 +3159,444 @@ describe('WorkflowEngine', () => {
             'step-2': { output: { prev: {} } },
           },
         });
+    });
+  });
+
+  describe('flow control', () => {
+    let engine: WorkflowEngine;
+
+    beforeEach(async () => {
+      engine = new WorkflowEngine({
+        workflows: [testWorkflow],
+        pool: testPool,
+        boss: testBoss,
+      });
+    });
+
+    afterEach(async () => {
+      await engine.stop();
+    });
+
+    it('queues and promotes concurrency-limited runs on cancellation', async () => {
+      const workflowId = 'flow-concurrency-cancel-promotion';
+      const scopedResourceId = workflowId;
+      const flowWorkflow = workflow(
+        workflowId,
+        async ({ step }) => {
+          await step.run('step-1', async () => 'ok');
+          return { ok: true };
+        },
+        {
+          flowControl: {
+            concurrency: () => ({ key: '__workflow__', limit: 1 }),
+          },
+        },
+      );
+
+      await engine.start(false);
+      await engine.registerWorkflow(flowWorkflow);
+
+      const run1 = await engine.startWorkflow({
+        resourceId: scopedResourceId,
+        workflowId,
+        input: {},
+      });
+      const run2 = await engine.startWorkflow({
+        resourceId: scopedResourceId,
+        workflowId,
+        input: {},
+      });
+
+      expect((await engine.getRun({ runId: run1.id, resourceId: scopedResourceId })).status).toBe(
+        WorkflowStatus.RUNNING,
+      );
+      expect((await engine.getRun({ runId: run2.id, resourceId: scopedResourceId })).status).toBe(
+        WorkflowStatus.PENDING,
+      );
+
+      await engine.cancelWorkflow({
+        runId: run1.id,
+        resourceId: scopedResourceId,
+      });
+
+      await expect
+        .poll(
+          async () =>
+            (await engine.getRun({ runId: run2.id, resourceId: scopedResourceId })).status,
+        )
+        .toBe(WorkflowStatus.RUNNING);
+    });
+
+    it('releases concurrency slots when a run is paused manually', async () => {
+      const workflowId = 'flow-concurrency-pause-promotion';
+      const scopedResourceId = workflowId;
+      const flowWorkflow = workflow(
+        workflowId,
+        async ({ step }) => {
+          await step.run('step-1', async () => 'ok');
+          return { ok: true };
+        },
+        {
+          flowControl: {
+            concurrency: () => ({ key: '__workflow__', limit: 1 }),
+          },
+        },
+      );
+
+      await engine.start(false);
+      await engine.registerWorkflow(flowWorkflow);
+
+      const run1 = await engine.startWorkflow({
+        resourceId: scopedResourceId,
+        workflowId,
+        input: {},
+      });
+      const run2 = await engine.startWorkflow({
+        resourceId: scopedResourceId,
+        workflowId,
+        input: {},
+      });
+
+      expect((await engine.getRun({ runId: run2.id, resourceId: scopedResourceId })).status).toBe(
+        WorkflowStatus.PENDING,
+      );
+
+      await engine.pauseWorkflow({
+        runId: run1.id,
+        resourceId: scopedResourceId,
+      });
+
+      await expect
+        .poll(
+          async () =>
+            (await engine.getRun({ runId: run2.id, resourceId: scopedResourceId })).status,
+        )
+        .toBe(WorkflowStatus.RUNNING);
+    });
+
+    it('does not head-of-line block a different concurrency key', async () => {
+      const workflowId = 'flow-concurrency-distinct-keys';
+      const scopedResourceId = workflowId;
+      const flowWorkflow = workflow(
+        workflowId,
+        async ({ step }) => {
+          await step.run('step-1', async () => 'ok');
+          return { ok: true };
+        },
+        {
+          inputSchema: z.object({ group: z.string() }),
+          flowControl: {
+            concurrency: (input) => ({ key: input.group, limit: 1 }),
+          },
+        },
+      );
+
+      await engine.start(false);
+      await engine.registerWorkflow(flowWorkflow);
+
+      const runA1 = await engine.startWorkflow({
+        resourceId: scopedResourceId,
+        workflowId,
+        input: { group: 'a' },
+      });
+      const runA2 = await engine.startWorkflow({
+        resourceId: scopedResourceId,
+        workflowId,
+        input: { group: 'a' },
+      });
+      const runB1 = await engine.startWorkflow({
+        resourceId: scopedResourceId,
+        workflowId,
+        input: { group: 'b' },
+      });
+
+      expect((await engine.getRun({ runId: runA1.id, resourceId: scopedResourceId })).status).toBe(
+        WorkflowStatus.RUNNING,
+      );
+      expect((await engine.getRun({ runId: runA2.id, resourceId: scopedResourceId })).status).toBe(
+        WorkflowStatus.PENDING,
+      );
+      expect((await engine.getRun({ runId: runB1.id, resourceId: scopedResourceId })).status).toBe(
+        WorkflowStatus.RUNNING,
+      );
+    });
+
+    it('returns the existing run for singleton skip and replaces it for singleton cancel', async () => {
+      const skipWorkflowId = 'flow-singleton-skip';
+      const cancelWorkflowId = 'flow-singleton-cancel';
+      const skipWorkflow = workflow(
+        skipWorkflowId,
+        async ({ step }) => {
+          await step.run('step-1', async () => 'ok');
+          return { ok: true };
+        },
+        {
+          inputSchema: z.object({ userId: z.string() }),
+          flowControl: {
+            singleton: (input) => ({ key: input.userId, mode: 'skip' }),
+          },
+        },
+      );
+      const cancelFlowWorkflow = workflow(
+        cancelWorkflowId,
+        async ({ step }) => {
+          await step.run('step-1', async () => 'ok');
+          return { ok: true };
+        },
+        {
+          inputSchema: z.object({ userId: z.string() }),
+          flowControl: {
+            singleton: (input) => ({ key: input.userId, mode: 'cancel' }),
+          },
+        },
+      );
+
+      await engine.start(false);
+      await engine.registerWorkflow(skipWorkflow);
+      await engine.registerWorkflow(cancelFlowWorkflow);
+
+      const skipped1 = await engine.startWorkflow({
+        resourceId: skipWorkflowId,
+        workflowId: skipWorkflowId,
+        input: { userId: 'user-1' },
+      });
+      const skipped2 = await engine.startWorkflow({
+        resourceId: skipWorkflowId,
+        workflowId: skipWorkflowId,
+        input: { userId: 'user-1' },
+      });
+
+      expect(skipped1.id).toBe(skipped2.id);
+
+      const cancelled1 = await engine.startWorkflow({
+        resourceId: cancelWorkflowId,
+        workflowId: cancelWorkflowId,
+        input: { userId: 'user-1' },
+      });
+      const cancelled2 = await engine.startWorkflow({
+        resourceId: cancelWorkflowId,
+        workflowId: cancelWorkflowId,
+        input: { userId: 'user-1' },
+      });
+
+      expect(cancelled1.id).not.toBe(cancelled2.id);
+      expect(
+        (await engine.getRun({ runId: cancelled1.id, resourceId: cancelWorkflowId })).status,
+      ).toBe(WorkflowStatus.CANCELLED);
+      expect(
+        (await engine.getRun({ runId: cancelled2.id, resourceId: cancelWorkflowId })).status,
+      ).toBe(WorkflowStatus.RUNNING);
+    });
+
+    it('keeps a paused wakeup blocked until capacity is available', async () => {
+      const workflowId = 'flow-concurrency-resume-requeue';
+      const scopedResourceId = workflowId;
+      const flowWorkflow = workflow(
+        workflowId,
+        async ({ step }) => {
+          await step.waitFor('gate', { eventName: 'go' });
+          await step.run('work', async () => {
+            await new Promise((resolve) => setTimeout(resolve, 150));
+            return 'done';
+          });
+          return { ok: true };
+        },
+        {
+          flowControl: {
+            concurrency: () => ({ key: '__workflow__', limit: 1 }),
+          },
+        },
+      );
+
+      await engine.start(false);
+      await engine.registerWorkflow(flowWorkflow);
+
+      const run1 = await engine.startWorkflow({
+        resourceId: scopedResourceId,
+        workflowId,
+        input: {},
+      });
+      const run2 = await engine.startWorkflow({
+        resourceId: scopedResourceId,
+        workflowId,
+        input: {},
+      });
+
+      const waitTimeline = {
+        [waitForTimelineKey('gate')]: {
+          waitFor: { eventName: 'go' },
+          timestamp: new Date(),
+        },
+      };
+
+      await engine.updateRun({
+        runId: run1.id,
+        resourceId: scopedResourceId,
+        data: {
+          status: WorkflowStatus.PAUSED,
+          currentStepId: 'gate',
+          pausedAt: new Date(),
+          pauseReason: 'waitFor',
+          timeline: waitTimeline,
+        },
+      });
+      await engine.updateRun({
+        runId: run2.id,
+        resourceId: scopedResourceId,
+        data: {
+          status: WorkflowStatus.PAUSED,
+          currentStepId: 'gate',
+          pausedAt: new Date(),
+          pauseReason: 'waitFor',
+          timeline: waitTimeline,
+        },
+      });
+
+      const run1Wake = (
+        engine as unknown as { handleWorkflowRun: (jobs: unknown[]) => Promise<void> }
+      ).handleWorkflowRun([
+        {
+          data: {
+            runId: run1.id,
+            resourceId: scopedResourceId,
+            workflowId,
+            event: { name: 'go', data: {} },
+          },
+        },
+      ]);
+
+      await new Promise((resolve) => setTimeout(resolve, 25));
+
+      await (
+        engine as unknown as { handleWorkflowRun: (jobs: unknown[]) => Promise<void> }
+      ).handleWorkflowRun([
+        {
+          data: {
+            runId: run2.id,
+            resourceId: scopedResourceId,
+            workflowId,
+            event: { name: 'go', data: {} },
+          },
+        },
+      ]);
+
+      expect((await engine.getRun({ runId: run2.id, resourceId: scopedResourceId })).status).toBe(
+        WorkflowStatus.PAUSED,
+      );
+
+      await run1Wake;
+
+      await expect
+        .poll(
+          async () =>
+            (await engine.getRun({ runId: run1.id, resourceId: scopedResourceId })).status,
+          {
+            timeout: 10_000,
+          },
+        )
+        .toBe(WorkflowStatus.COMPLETED);
+
+      await (
+        engine as unknown as { handleWorkflowRun: (jobs: unknown[]) => Promise<void> }
+      ).handleWorkflowRun([
+        {
+          data: {
+            runId: run2.id,
+            resourceId: scopedResourceId,
+            workflowId,
+            event: { name: 'go', data: {} },
+          },
+        },
+      ]);
+
+      await expect
+        .poll(
+          async () =>
+            (await engine.getRun({ runId: run2.id, resourceId: scopedResourceId })).status,
+          {
+            timeout: 10_000,
+          },
+        )
+        .toBe(WorkflowStatus.COMPLETED);
+    });
+
+    it('does not apply singleton dedup across invokeChildWorkflow parents', async () => {
+      const childWorkflowId = 'flow-child-singleton-ignore';
+      const parentWorkflowId = 'flow-parent-singleton-ignore';
+      const scopedResourceId = parentWorkflowId;
+      const childWorkflow = workflow(
+        childWorkflowId,
+        async ({ step }) => {
+          await step.waitFor('gate', { eventName: 'child-ready' });
+          return { ok: true };
+        },
+        {
+          inputSchema: z.object({ userId: z.string() }),
+          flowControl: {
+            singleton: (input) => ({ key: input.userId, mode: 'skip' }),
+          },
+        },
+      );
+      const parentWorkflow = workflow(
+        parentWorkflowId,
+        async ({ step, input }) => {
+          await step.invokeChildWorkflow('child', {
+            workflowId: childWorkflowId,
+            input: { userId: input.userId },
+          });
+          return { ok: true };
+        },
+        {
+          inputSchema: z.object({ userId: z.string() }),
+        },
+      );
+
+      await engine.start(false);
+      await engine.registerWorkflow(childWorkflow);
+      await engine.registerWorkflow(parentWorkflow);
+
+      const parentRun1 = await engine.startWorkflow({
+        resourceId: scopedResourceId,
+        workflowId: parentWorkflowId,
+        input: { userId: 'user-1' },
+      });
+      const parentRun2 = await engine.startWorkflow({
+        resourceId: scopedResourceId,
+        workflowId: parentWorkflowId,
+        input: { userId: 'user-1' },
+      });
+
+      const invokeParent = engine as unknown as {
+        handleWorkflowRun: (jobs: unknown[]) => Promise<void>;
+      };
+
+      await invokeParent.handleWorkflowRun([
+        {
+          data: {
+            runId: parentRun1.id,
+            resourceId: scopedResourceId,
+            workflowId: parentWorkflowId,
+          },
+        },
+      ]);
+      await invokeParent.handleWorkflowRun([
+        {
+          data: {
+            runId: parentRun2.id,
+            resourceId: scopedResourceId,
+            workflowId: parentWorkflowId,
+          },
+        },
+      ]);
+
+      expect(
+        (
+          await engine.getRuns({
+            resourceId: scopedResourceId,
+            workflowId: childWorkflowId,
+          })
+        ).items.length,
+      ).toBe(2);
     });
   });
 });

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -13,13 +13,20 @@ import {
 } from './constants';
 import { runMigrations } from './db/migration';
 import {
+  acquireIdempotencyKeyLock,
+  acquireWorkflowAdmissionLock,
+  cancelConflictingSingletonRuns,
+  countRunningWorkflowRunsByConcurrencyKey,
+  findOldestConflictingSingletonRun,
+  getPendingWorkflowRunsByWorkflowId,
   getWorkflowRun,
+  getWorkflowRunByIdempotencyKey,
   getWorkflowRuns,
   insertWorkflowRun,
   updateWorkflowRun,
   withPostgresTransaction,
 } from './db/queries';
-import type { WorkflowRun } from './db/types';
+import type { PersistedWorkflowRun, WorkflowRun } from './db/types';
 import type { Duration } from './duration';
 import { parseDuration } from './duration';
 import {
@@ -28,6 +35,11 @@ import {
   WorkflowEngineError,
   WorkflowRunNotFoundError,
 } from './error';
+import {
+  assertValidFlowControl,
+  type ResolvedFlowControl,
+  resolveFlowControl,
+} from './flow-control';
 import {
   type InferInputParameters,
   type InputParameters,
@@ -137,6 +149,18 @@ const getInvokeChildWorkflowEventName = (childRunId: string) =>
 const defaultHeartbeatSeconds = process.env.WORKFLOW_RUN_HEARTBEAT_SECONDS
   ? Number.parseInt(process.env.WORKFLOW_RUN_HEARTBEAT_SECONDS, 10)
   : 30;
+
+const PAUSE_REASON_WAIT_FOR = 'waitFor';
+const PAUSE_REASON_WAIT_UNTIL = 'waitUntil';
+const PAUSE_REASON_POLL = 'poll';
+const PAUSE_REASON_MANUAL = 'manual';
+const PAUSE_REASON_INVOKE_CHILD_WORKFLOW = 'invokeChildWorkflow';
+const CONCURRENCY_BLOCKED_RETRY_DELAY_MS = 1000;
+
+type StartAdmissionResult = {
+  run: PersistedWorkflowRun;
+  created: boolean;
+};
 
 export class WorkflowEngine {
   private boss: PgBoss;
@@ -271,6 +295,15 @@ export class WorkflowEngine {
     if (this.workflows.has(definition.id)) {
       throw new WorkflowEngineError(
         `Workflow ${definition.id} is already registered`,
+        definition.id,
+      );
+    }
+
+    try {
+      assertValidFlowControl(definition.flowControl, `workflow("${definition.id}")`);
+    } catch (error) {
+      throw new WorkflowEngineError(
+        error instanceof Error ? error.message : String(error),
         definition.id,
       );
     }
@@ -410,6 +443,7 @@ export class WorkflowEngine {
     parentResourceId,
     enqueue = true,
     db,
+    ignoreSingleton = false,
   }: {
     workflowId: string;
     input: unknown;
@@ -421,7 +455,8 @@ export class WorkflowEngine {
     parentResourceId?: string;
     enqueue?: boolean;
     db?: Db;
-  }): Promise<{ run: WorkflowRun; created: boolean }> {
+    ignoreSingleton?: boolean;
+  }): Promise<StartAdmissionResult> {
     validateWorkflowId(workflowId);
     validateResourceId(resourceId);
 
@@ -448,6 +483,20 @@ export class WorkflowEngine {
       }
     }
 
+    let resolvedFlowControl: ResolvedFlowControl | null = null;
+    try {
+      const resolved = resolveFlowControl(
+        workflow.flowControl,
+        input as InferInputParameters<InputParameters>,
+      );
+      resolvedFlowControl = ignoreSingleton && resolved?.type === 'singleton' ? null : resolved;
+    } catch (error) {
+      throw new WorkflowEngineError(
+        error instanceof Error ? error.message : String(error),
+        workflowId,
+      );
+    }
+
     const initialStepId = workflow.steps[0]?.id ?? '__start__';
     const timeoutAt = options?.timeout
       ? new Date(Date.now() + options.timeout)
@@ -455,17 +504,74 @@ export class WorkflowEngine {
         ? new Date(Date.now() + workflow.timeout)
         : null;
 
-    const insertRun = async (targetDb: Db) =>
-      await insertWorkflowRun(
+    const admitRun = async (targetDb: Db): Promise<StartAdmissionResult> => {
+      if (idempotencyKey) {
+        await acquireIdempotencyKeyLock(idempotencyKey, targetDb);
+        const existingByIdempotency = await getWorkflowRunByIdempotencyKey(
+          idempotencyKey,
+          targetDb,
+        );
+        if (existingByIdempotency) {
+          return { run: existingByIdempotency, created: false };
+        }
+      }
+
+      await acquireWorkflowAdmissionLock(workflowId, targetDb);
+
+      if (resolvedFlowControl?.type === 'singleton') {
+        const existingSingleton = await findOldestConflictingSingletonRun(
+          {
+            workflowId,
+            concurrencyKey: resolvedFlowControl.concurrencyKey,
+          },
+          targetDb,
+        );
+
+        if (existingSingleton) {
+          if (resolvedFlowControl.singletonMode === 'skip') {
+            return { run: existingSingleton, created: false };
+          }
+
+          await cancelConflictingSingletonRuns(
+            {
+              workflowId,
+              concurrencyKey: resolvedFlowControl.concurrencyKey,
+            },
+            targetDb,
+          );
+        }
+      }
+
+      const isConcurrencyLimited = resolvedFlowControl?.type === 'concurrency';
+      const status =
+        isConcurrencyLimited &&
+        (await countRunningWorkflowRunsByConcurrencyKey(
+          {
+            workflowId,
+            concurrencyKey: resolvedFlowControl.concurrencyKey,
+          },
+          targetDb,
+        )) >= resolvedFlowControl.concurrencyLimit
+          ? WorkflowStatus.PENDING
+          : WorkflowStatus.RUNNING;
+
+      const result = await insertWorkflowRun(
         {
           resourceId,
           workflowId,
           currentStepId: initialStepId,
-          status: WorkflowStatus.RUNNING,
+          status,
           input,
           maxRetries: options?.retries ?? workflow.retries ?? 0,
           timeoutAt,
           idempotencyKey,
+          concurrencyKey: resolvedFlowControl?.concurrencyKey ?? null,
+          concurrencyLimit:
+            resolvedFlowControl?.type === 'concurrency'
+              ? resolvedFlowControl.concurrencyLimit
+              : null,
+          singletonMode:
+            resolvedFlowControl?.type === 'singleton' ? resolvedFlowControl.singletonMode : null,
           parentRunId,
           parentStepId,
           parentResourceId,
@@ -473,36 +579,25 @@ export class WorkflowEngine {
         targetDb,
       );
 
-    const { run, created } = db
-      ? await insertRun(db)
-      : await withPostgresTransaction(
-          this.boss.getDb(),
-          async (transactionDb) => {
-            const result = await insertRun(transactionDb);
-            if (enqueue && result.created) {
-              // Pipe the same transaction connection through pg-boss so the
-              // INSERT into workflow_runs and the INSERT into pgboss.job
-              // commit (or roll back) together. If `boss.send` throws, the
-              // workflow_runs row is rolled back too, so we never end up with
-              // an orphan run that has no job, or a job that points at no run.
-              await this.enqueueWorkflowRun(result.run, options, transactionDb);
-            }
-            return result;
-          },
-          this.pool,
-        );
+      if (enqueue && result.created && result.run.status === WorkflowStatus.RUNNING) {
+        await this.enqueueWorkflowRun(result.run, options, targetDb);
+      }
 
-    if (db && enqueue && created) {
-      await this.enqueueWorkflowRun(run, options);
+      return result;
+    };
+
+    if (db) {
+      return admitRun(db);
     }
 
-    return { run, created };
+    return withPostgresTransaction(this.boss.getDb(), admitRun, this.pool);
   }
 
   private async enqueueWorkflowRun(
     run: WorkflowRun,
     options?: { expireInSeconds?: number },
     db?: Db,
+    startAfter?: Date,
   ) {
     const job: WorkflowRunJobParameters = {
       runId: run.id,
@@ -512,11 +607,157 @@ export class WorkflowEngine {
     };
 
     await this.boss.send(WORKFLOW_RUN_QUEUE_NAME, job, {
-      startAfter: new Date(),
+      startAfter: startAfter ?? new Date(),
       expireInSeconds: options?.expireInSeconds ?? defaultExpireInSeconds,
       ...retrySendOptions(run.maxRetries),
       ...(db ? { db } : {}),
     });
+  }
+
+  private async enqueueWorkflowEvent(
+    {
+      run,
+      eventName,
+      data,
+    }: {
+      run: PersistedWorkflowRun;
+      eventName: string;
+      data?: unknown;
+    },
+    options?: { expireInSeconds?: number },
+    db?: Db,
+    startAfter?: Date,
+  ) {
+    await this.boss.send(
+      WORKFLOW_RUN_QUEUE_NAME,
+      {
+        runId: run.id,
+        resourceId: run.resourceId ?? undefined,
+        workflowId: run.workflowId,
+        input: run.input,
+        event: {
+          name: eventName,
+          data,
+        },
+      },
+      {
+        startAfter: startAfter ?? new Date(),
+        expireInSeconds: options?.expireInSeconds ?? defaultExpireInSeconds,
+        ...retrySendOptions(run.maxRetries),
+        ...(db ? { db } : {}),
+      },
+    );
+  }
+
+  private async canRunNow(run: PersistedWorkflowRun, db: Db): Promise<boolean> {
+    if (!run.concurrencyKey || !run.concurrencyLimit) {
+      return true;
+    }
+
+    const activeCount = await countRunningWorkflowRunsByConcurrencyKey(
+      {
+        workflowId: run.workflowId,
+        concurrencyKey: run.concurrencyKey,
+      },
+      db,
+    );
+
+    return activeCount < run.concurrencyLimit;
+  }
+
+  private async promotePendingRuns(
+    workflowId: string,
+    options?: { expireInSeconds?: number },
+  ): Promise<void> {
+    await withPostgresTransaction(
+      this.db,
+      async (db) => {
+        await acquireWorkflowAdmissionLock(workflowId, db);
+
+        const pendingRuns = await getPendingWorkflowRunsByWorkflowId(workflowId, db);
+        const runningCounts = new Map<string, number>();
+
+        for (const pendingRun of pendingRuns) {
+          if (!pendingRun.concurrencyKey || !pendingRun.concurrencyLimit) {
+            const promoted = await this.updateRun(
+              {
+                runId: pendingRun.id,
+                resourceId: pendingRun.resourceId ?? undefined,
+                data: {
+                  status: WorkflowStatus.RUNNING,
+                  pausedAt: null,
+                  pauseReason: null,
+                },
+                expectedStatuses: [WorkflowStatus.PENDING],
+              },
+              { db },
+            );
+
+            await this.enqueueWorkflowRun(promoted, options, db);
+            continue;
+          }
+
+          const currentCount =
+            runningCounts.get(pendingRun.concurrencyKey) ??
+            (await countRunningWorkflowRunsByConcurrencyKey(
+              {
+                workflowId,
+                concurrencyKey: pendingRun.concurrencyKey,
+              },
+              db,
+            ));
+
+          if (currentCount >= pendingRun.concurrencyLimit) {
+            runningCounts.set(pendingRun.concurrencyKey, currentCount);
+            continue;
+          }
+
+          const promoted = await this.updateRun(
+            {
+              runId: pendingRun.id,
+              resourceId: pendingRun.resourceId ?? undefined,
+              data: {
+                status: WorkflowStatus.RUNNING,
+                pausedAt: null,
+                pauseReason: null,
+              },
+              expectedStatuses: [WorkflowStatus.PENDING],
+            },
+            { db },
+          );
+
+          runningCounts.set(pendingRun.concurrencyKey, currentCount + 1);
+          await this.enqueueWorkflowRun(promoted, options, db);
+        }
+      },
+      this.pool,
+    );
+  }
+
+  private async requeueBlockedPausedRun(
+    run: PersistedWorkflowRun,
+    event?: WorkflowRunJobParameters['event'],
+  ): Promise<void> {
+    if (event?.name) {
+      await this.enqueueWorkflowEvent(
+        {
+          run,
+          eventName: event.name,
+          data: event.data,
+        },
+        undefined,
+        undefined,
+        new Date(Date.now() + CONCURRENCY_BLOCKED_RETRY_DELAY_MS),
+      );
+      return;
+    }
+
+    await this.enqueueWorkflowRun(
+      run,
+      undefined,
+      undefined,
+      new Date(Date.now() + CONCURRENCY_BLOCKED_RETRY_DELAY_MS),
+    );
   }
 
   private async notifyParentOfChildTerminalRun(childRun: WorkflowRun) {
@@ -563,9 +804,12 @@ export class WorkflowEngine {
       data: {
         status: WorkflowStatus.PAUSED,
         pausedAt: new Date(),
+        pauseReason: PAUSE_REASON_MANUAL,
       },
       expectedStatuses: [WorkflowStatus.RUNNING, WorkflowStatus.PENDING],
     });
+
+    await this.promotePendingRuns(run.workflowId);
 
     this.logger.log('Paused workflow run', {
       runId,
@@ -698,6 +942,7 @@ export class WorkflowEngine {
       resourceId,
       data: {
         status: WorkflowStatus.CANCELLED,
+        pauseReason: null,
       },
       expectedStatuses: [WorkflowStatus.PENDING, WorkflowStatus.RUNNING, WorkflowStatus.PAUSED],
     });
@@ -705,6 +950,7 @@ export class WorkflowEngine {
     this.logger.log(`cancelled workflow run with id ${runId}`);
 
     await this.notifyParentOfChildTerminalRun(run);
+    await this.promotePendingRuns(run.workflowId);
 
     return run;
   }
@@ -753,7 +999,7 @@ export class WorkflowEngine {
   async getRun(
     { runId, resourceId }: { runId: string; resourceId?: string },
     { exclusiveLock = false, db }: { exclusiveLock?: boolean; db?: Db } = {},
-  ): Promise<WorkflowRun> {
+  ): Promise<PersistedWorkflowRun> {
     const run = await getWorkflowRun({ runId, resourceId }, { exclusiveLock, db: db ?? this.db });
 
     if (!run) {
@@ -772,11 +1018,11 @@ export class WorkflowEngine {
     }: {
       runId: string;
       resourceId?: string;
-      data: Partial<WorkflowRun>;
+      data: Partial<PersistedWorkflowRun>;
       expectedStatuses?: string[];
     },
     { db }: { db?: Db } = {},
-  ): Promise<WorkflowRun> {
+  ): Promise<PersistedWorkflowRun> {
     const run = await updateWorkflowRun(
       { runId, resourceId, data, expectedStatuses },
       db ?? this.db,
@@ -879,8 +1125,9 @@ export class WorkflowEngine {
   private async handleWorkflowRun([job]: JobWithMetadata<WorkflowRunJobParameters>[]) {
     const { runId = '', resourceId, workflowId = '', event } = job?.data ?? {};
 
-    let run: WorkflowRun | undefined;
+    let run: PersistedWorkflowRun | undefined;
     let scopedResourceId: string | undefined;
+    let blockedByConcurrency = false;
 
     try {
       if (!runId) {
@@ -966,6 +1213,11 @@ export class WorkflowEngine {
               (event.name === waitFor.eventName || event.name === waitFor.timeoutEvent) &&
               !hasCurrentStepOutput;
 
+            if (!(await this.canRunNow(lockedRun, db))) {
+              blockedByConcurrency = true;
+              return lockedRun;
+            }
+
             if (eventMatches) {
               const isTimeout = event?.name === waitFor?.timeoutEvent;
               const skipOutput = waitFor?.skipOutput;
@@ -976,6 +1228,7 @@ export class WorkflowEngine {
                   data: {
                     status: WorkflowStatus.RUNNING,
                     pausedAt: null,
+                    pauseReason: null,
                     resumedAt: new Date(),
                     jobId: job?.id,
                     ...(skipOutput
@@ -1002,6 +1255,7 @@ export class WorkflowEngine {
                 data: {
                   status: WorkflowStatus.RUNNING,
                   pausedAt: null,
+                  pauseReason: null,
                   resumedAt: new Date(),
                   jobId: job?.id,
                 },
@@ -1011,6 +1265,11 @@ export class WorkflowEngine {
           },
           this.pool,
         );
+
+        if (blockedByConcurrency) {
+          await this.requeueBlockedPausedRun(run, event);
+          return;
+        }
       }
 
       const baseStep = {
@@ -1166,6 +1425,7 @@ export class WorkflowEngine {
           },
         });
         await this.notifyParentOfChildTerminalRun(completedRun);
+        await this.promotePendingRuns(completedRun.workflowId);
 
         this.logger.log('Workflow run completed.', {
           runId,
@@ -1191,6 +1451,7 @@ export class WorkflowEngine {
           updatedRun.status === WorkflowStatus.CANCELLED
         ) {
           await this.notifyParentOfChildTerminalRun(updatedRun);
+          await this.promotePendingRuns(updatedRun.workflowId);
         }
       }
 
@@ -1221,6 +1482,7 @@ export class WorkflowEngine {
       },
     });
     await this.notifyParentOfChildTerminalRun(failedRun);
+    await this.promotePendingRuns(failedRun.workflowId);
 
     this.logger.log('Marked stuck workflow run as failed', {
       runId,
@@ -1413,6 +1675,7 @@ export class WorkflowEngine {
             stepId,
             eventName: getInvokeChildWorkflowEventName(existingChildRun.id),
             skipOutput: true,
+            pauseReason: PAUSE_REASON_INVOKE_CHILD_WORKFLOW,
             db,
           });
           childRunToEnqueue = existingChildRun;
@@ -1429,6 +1692,7 @@ export class WorkflowEngine {
           parentStepId: stepId,
           parentResourceId: run.resourceId ?? undefined,
           enqueue: false,
+          ignoreSingleton: true,
           db,
         });
         const childRun = result.run;
@@ -1486,6 +1750,7 @@ export class WorkflowEngine {
           stepId,
           eventName: getInvokeChildWorkflowEventName(childRun.id),
           skipOutput: true,
+          pauseReason: PAUSE_REASON_INVOKE_CHILD_WORKFLOW,
           db,
           timeline: merge(lockedRun.timeline, {
             [invokeChildWorkflowTimelineKey(stepId)]: {
@@ -1514,6 +1779,7 @@ export class WorkflowEngine {
         childRun: childRunToEnqueue,
         options,
       });
+      await this.promotePendingRuns(parentRunForRevert.workflowId);
     }
   }
 
@@ -1543,6 +1809,7 @@ export class WorkflowEngine {
           data: {
             status: WorkflowStatus.RUNNING,
             pausedAt: null,
+            pauseReason: null,
           },
           expectedStatuses: [WorkflowStatus.PAUSED],
         });
@@ -1572,6 +1839,7 @@ export class WorkflowEngine {
     eventName,
     timeoutEvent,
     skipOutput,
+    pauseReason,
     db,
     timeline,
   }: {
@@ -1580,6 +1848,7 @@ export class WorkflowEngine {
     eventName?: string;
     timeoutEvent?: string;
     skipOutput?: true;
+    pauseReason: string;
     db?: Db;
     timeline?: Record<string, unknown>;
   }) {
@@ -1597,6 +1866,7 @@ export class WorkflowEngine {
           status: WorkflowStatus.PAUSED,
           currentStepId: stepId,
           pausedAt: new Date(),
+          pauseReason,
           timeline: merge(baseTimeline, {
             [waitForTimelineKey(stepId)]: {
               waitFor,
@@ -1750,7 +2020,19 @@ export class WorkflowEngine {
           { runId: run.id, resourceId: run.resourceId ?? undefined },
           { exclusiveLock: true, db },
         );
-        return this.pauseRunForWait({ run: freshRun, stepId, eventName, timeoutEvent, db });
+        return this.pauseRunForWait({
+          run: freshRun,
+          stepId,
+          eventName,
+          timeoutEvent,
+          pauseReason:
+            eventName === PAUSE_EVENT_NAME
+              ? PAUSE_REASON_MANUAL
+              : timeoutDate
+                ? PAUSE_REASON_WAIT_UNTIL
+                : PAUSE_REASON_WAIT_FOR,
+          db,
+        });
       },
       this.pool,
     );
@@ -1774,11 +2056,13 @@ export class WorkflowEngine {
         await this.updateRun({
           runId: run.id,
           resourceId: run.resourceId ?? undefined,
-          data: { status: WorkflowStatus.RUNNING, pausedAt: null },
+          data: { status: WorkflowStatus.RUNNING, pausedAt: null, pauseReason: null },
         });
         throw error;
       }
     }
+
+    await this.promotePendingRuns(run.workflowId);
 
     this.logger.log(
       `Step ${stepId} waiting${eventName ? ` for event "${eventName}"` : ''}${timeoutDate ? ` until ${timeoutDate.toISOString()}` : ''}`,
@@ -1934,6 +2218,7 @@ export class WorkflowEngine {
               status: WorkflowStatus.PAUSED,
               currentStepId: stepId,
               pausedAt: new Date(),
+              pauseReason: PAUSE_REASON_POLL,
               timeline: merge(freshRun.timeline, {
                 [`${stepId}-poll`]: { startedAt: startedAt.toISOString() },
                 [waitForTimelineKey(stepId)]: {
@@ -1970,10 +2255,12 @@ export class WorkflowEngine {
       await this.updateRun({
         runId: run.id,
         resourceId: run.resourceId ?? undefined,
-        data: { status: WorkflowStatus.RUNNING, pausedAt: null },
+        data: { status: WorkflowStatus.RUNNING, pausedAt: null, pauseReason: null },
       });
       throw error;
     }
+
+    await this.promotePendingRuns(run.workflowId);
 
     this.logger.log(`Step ${stepId} polling every ${intervalMs}ms...`, {
       runId: run.id,

--- a/src/flow-control.ts
+++ b/src/flow-control.ts
@@ -1,0 +1,78 @@
+import type { InferInputParameters, InputParameters, WorkflowFlowControl } from './types';
+
+export type ResolvedFlowControl =
+  | {
+      type: 'concurrency';
+      concurrencyKey: string;
+      concurrencyLimit: number;
+    }
+  | {
+      type: 'singleton';
+      concurrencyKey: string;
+      singletonMode: 'skip' | 'cancel';
+    }
+  | null;
+
+export function assertValidFlowControl(
+  flowControl: WorkflowFlowControl | undefined,
+  owner: string,
+): void {
+  if (flowControl?.concurrency && flowControl.singleton) {
+    throw new Error(
+      `${owner} cannot define both flowControl.concurrency and flowControl.singleton`,
+    );
+  }
+}
+
+export function resolveFlowControl<I extends InputParameters>(
+  flowControl: WorkflowFlowControl<I> | undefined,
+  input: InferInputParameters<I>,
+): ResolvedFlowControl {
+  if (!flowControl) {
+    return null;
+  }
+
+  if (flowControl.concurrency) {
+    const resolved = flowControl.concurrency(input);
+    const key = resolved?.key?.trim();
+
+    if (!key) {
+      throw new Error('flowControl.concurrency must return a non-empty key');
+    }
+
+    if (
+      !Number.isInteger(resolved.limit) ||
+      typeof resolved.limit !== 'number' ||
+      resolved.limit < 1
+    ) {
+      throw new Error('flowControl.concurrency must return a positive integer limit');
+    }
+
+    return {
+      type: 'concurrency',
+      concurrencyKey: key,
+      concurrencyLimit: resolved.limit,
+    };
+  }
+
+  if (flowControl.singleton) {
+    const resolved = flowControl.singleton(input);
+    const key = resolved?.key?.trim();
+
+    if (!key) {
+      throw new Error('flowControl.singleton must return a non-empty key');
+    }
+
+    if (resolved.mode !== 'skip' && resolved.mode !== 'cancel') {
+      throw new Error("flowControl.singleton must return mode 'skip' or 'cancel'");
+    }
+
+    return {
+      type: 'singleton',
+      concurrencyKey: key,
+      singletonMode: resolved.mode,
+    };
+  }
+
+  return null;
+}

--- a/src/migration-lock.integration.test.ts
+++ b/src/migration-lock.integration.test.ts
@@ -55,7 +55,7 @@ describe('Migration advisory lock (real PostgreSQL)', () => {
 
     // Verify the final schema state is correct
     const versionResult = await pool.query('SELECT version FROM workflow_schema_version LIMIT 1');
-    expect(versionResult.rows[0].version).toBe(4);
+    expect(versionResult.rows[0].version).toBe(5);
 
     const tableExists = await pool.query(`
       SELECT EXISTS (
@@ -73,12 +73,26 @@ describe('Migration advisory lock (real PostgreSQL)', () => {
           AND table_name = 'workflow_runs'
           AND column_name = ANY($1)
       `,
-      [['parent_run_id', 'parent_step_id', 'parent_resource_id']],
+      [
+        [
+          'parent_run_id',
+          'parent_step_id',
+          'parent_resource_id',
+          'concurrency_key',
+          'concurrency_limit',
+          'singleton_mode',
+          'pause_reason',
+        ],
+      ],
     );
     expect(parentColumnResult.rows.map((row) => row.column_name).sort()).toEqual([
+      'concurrency_key',
+      'concurrency_limit',
       'parent_resource_id',
       'parent_run_id',
       'parent_step_id',
+      'pause_reason',
+      'singleton_mode',
     ]);
   });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,19 @@ export enum StepType {
 export type InputParameters = StandardSchemaV1;
 export type InferInputParameters<P extends InputParameters> = StandardSchemaV1.InferOutput<P>;
 
+export type WorkflowConcurrencyResolver<I extends InputParameters = InputParameters> = (
+  input: InferInputParameters<I>,
+) => { key: string; limit: number };
+
+export type WorkflowSingletonResolver<I extends InputParameters = InputParameters> = (
+  input: InferInputParameters<I>,
+) => { key: string; mode: 'skip' | 'cancel' };
+
+export type WorkflowFlowControl<I extends InputParameters = InputParameters> = {
+  concurrency?: WorkflowConcurrencyResolver<I>;
+  singleton?: WorkflowSingletonResolver<I>;
+};
+
 export type WorkflowRunOptions = {
   resourceId?: string;
   timeout?: number;
@@ -36,6 +49,12 @@ export type WorkflowOptions<I extends InputParameters> = {
   timeout?: number;
   retries?: number;
   inputSchema?: I;
+  flowControl?: WorkflowFlowControl<I>;
+};
+
+export type WorkflowRefOptions<I extends InputParameters> = {
+  inputSchema?: I;
+  flowControl?: WorkflowFlowControl<I>;
 };
 
 export type StepBaseContext = {
@@ -118,6 +137,7 @@ export type WorkflowDefinition<TInput extends InputParameters = InputParameters>
   inputSchema?: TInput;
   timeout?: number; // milliseconds
   retries?: number;
+  flowControl?: WorkflowFlowControl<TInput>;
   plugins?: WorkflowPlugin[];
 };
 
@@ -149,7 +169,7 @@ export interface WorkflowFactory<TStepExt = object> {
   ): WorkflowFactory<TStepExt & TNewExt>;
   ref<TInput extends InputParameters = InputParameters, TOutput = unknown>(
     id: string,
-    options?: { inputSchema?: TInput },
+    options?: WorkflowRefOptions<TInput>,
   ): WorkflowRef<TInput, TOutput>;
 }
 
@@ -167,10 +187,11 @@ export interface WorkflowRef<
 > {
   (
     handler: (context: WorkflowContext<TInput, StepBaseContext>) => Promise<unknown>,
-    options?: Omit<WorkflowOptions<TInput>, 'inputSchema'>,
+    options?: Omit<WorkflowOptions<TInput>, 'inputSchema' | 'flowControl'>,
   ): WorkflowDefinition<TInput>;
   readonly id: string;
   readonly inputSchema?: TInput;
+  readonly flowControl?: WorkflowFlowControl<TInput>;
 }
 
 export type WorkflowRunProgress = WorkflowRun & {


### PR DESCRIPTION
## Summary

This PR adds Flow Control v1 to `pg-workflows` with workflow-defined `concurrency` and `singleton` policies.

New API:

```ts
flowControl?: {
  concurrency?: (input) => ({ key: string; limit: number })
  singleton?: (input) => ({ key: string; mode: 'skip' | 'cancel' })
}
```

`concurrency` and `singleton` are mutually exclusive.

## What’s Included

### Flow control API
- Adds `flowControl` to workflow definitions and `WorkflowRef`s
- Supports:
  - `concurrency`: keyed active-run limits
  - `singleton`: keyed whole-run exclusivity with `skip` or `cancel`
- Validates that both modes cannot be configured together

### Engine behavior
- Resolves flow-control keys at run creation time
- Queues concurrency-blocked runs as `pending`
- Promotes pending runs when capacity opens
- Re-checks concurrency before paused runs re-enter `running`
- Applies singleton semantics transactionally:
  - `skip`: return existing non-terminal run
  - `cancel`: cancel conflicting runs, then start the new run
- Does not share singleton child runs across different parents

### Client behavior
- `WorkflowClient.startWorkflow(ref, input, ...)` supports flow control because refs carry resolvers
- Raw `WorkflowClient.startWorkflow({ workflowId, ... })` does not evaluate callback-based flow control
- `WorkflowEngine.startWorkflow({ workflowId, ... })` remains flow-control aware because the engine has the registered definition

### Persistence / schema
- Adds run metadata and scheduling support in `workflow_runs`
- New columns:
  - `concurrency_key`
  - `concurrency_limit`
  - `singleton_mode`
  - `pause_reason`
- Adds new scheduler / lookup indexes
- Bumps schema version to `5`

### Public run shape
- `WorkflowRun` now exposes:
  - `concurrencyKey`
  - `pauseReason`

## Docs
- Adds flow-control docs and examples
- Explains `concurrency` vs `singleton` vs `idempotencyKey`
- Documents the raw client overload limitation and recommends shared `WorkflowRef`s for microservice setups

## Tests
Added and updated coverage for:
- workflow-level / constant-key concurrency
- keyed concurrency queueing and promotion
- paused runs releasing slots
- wakeup re-entry respecting concurrency
- head-of-line blocking avoidance across keys
- singleton `skip`
- singleton `cancel`
- child workflow edge cases
- migration version / new schema columns
- client ref behavior vs raw object starts

## Validation
Passed locally:
- `npm run lint`
- `npm run build`
- `npm run test:unit`
- `npm run test:integration`

## Migration Notes
- This introduces schema version `5`
- Integration expectations were updated to reflect the new migration and columns