### PR TITLE
fix: keep context.timeline live across steps within a handler invocation

### DIFF
--- a/src/engine.test.ts
+++ b/src/engine.test.ts
@@ -1684,6 +1684,40 @@ describe('WorkflowEngine', () => {
       expect(Object.keys(completedRun.timeline)).toHaveLength(3);
     });
 
+    it('should expose completed step outputs via context.timeline mid-handler', async () => {
+      const observed: Record<string, Record<string, unknown>> = {};
+
+      const timelineReadWorkflow = workflow('timeline-read-workflow', async (context) => {
+        const { step } = context;
+        observed.beforeStep1 = { ...context.timeline };
+        await step.run('step-1', async () => 'result-1');
+        observed.afterStep1 = { ...context.timeline };
+        await step.run('step-2', async () => ({ nested: 'value' }));
+        observed.afterStep2 = { ...context.timeline };
+        return 'done';
+      });
+
+      await engine.registerWorkflow(timelineReadWorkflow);
+      const run = await engine.startWorkflow({
+        resourceId,
+        workflowId: 'timeline-read-workflow',
+        input: {},
+      });
+
+      await expect
+        .poll(async () => (await engine.getRun({ runId: run.id, resourceId })).status)
+        .toBe(WorkflowStatus.COMPLETED);
+
+      expect(observed.beforeStep1).toEqual({});
+      expect(observed.afterStep1).toMatchObject({
+        'step-1': { output: 'result-1' },
+      });
+      expect(observed.afterStep2).toMatchObject({
+        'step-1': { output: 'result-1' },
+        'step-2': { output: { nested: 'value' } },
+      });
+    });
+
     it('should preserve timeline entries from before pause through resume', async () => {
       const pauseTimelineWorkflow = workflow('pause-timeline-workflow', async ({ step }) => {
         await step.run('step-1', async () => 'before-pause');

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1132,7 +1132,11 @@ export class WorkflowEngine {
         input: run.input as InferInputParameters<InputParameters>,
         workflowId: run.workflowId,
         runId: run.id,
-        timeline: run.timeline,
+        get timeline() {
+          // Read through to the live run so callers see entries written by
+          // previously completed steps within the same handler invocation.
+          return run?.timeline ?? {};
+        },
         logger: this.logger,
         step,
       };
@@ -1609,7 +1613,7 @@ export class WorkflowEngine {
             output = {};
           }
 
-          run = await this.updateRun(
+          const updated = await this.updateRun(
             {
               runId: run.id,
               resourceId: run.resourceId ?? undefined,
@@ -1624,6 +1628,10 @@ export class WorkflowEngine {
             },
             { db },
           );
+          // Mutate in place so handleWorkflowRun's `run` (same reference)
+          // — and the context.timeline getter that reads through it —
+          // observes the new step entry.
+          Object.assign(run, updated);
 
           return output;
         } catch (error) {


### PR DESCRIPTION
## Summary
- `context.timeline` was a snapshot of `run.timeline` taken at handler entry, so authors reading it between `step.run` calls always saw the initial (empty) timeline.
- Compounding the bug, `runStep`'s `run = await this.updateRun(...)` only reassigned its local parameter — the outer `handleWorkflowRun`'s `run.timeline` was never advanced during the handler either.
- Make `context.timeline` a getter that reads through to the live `run`, and have `runStep` mutate the shared `run` object in place via `Object.assign` so the getter observes each newly-written step entry.

Fixes #14.

## Test plan
- [x] New test `should expose completed step outputs via context.timeline mid-handler` reads `context.timeline` before, between, and after two `step.run` calls and asserts each observation reflects the completed steps. Fails without the fix (sees `{}` after step-1); passes with it.
- [x] Existing `should accumulate timeline entries across multiple sequential steps` and `should preserve timeline entries from before pause through resume` still pass.
- [x] `npm run lint` clean.
- [x] Remaining engine-test failures (`error and retry`, `delegate retries`, `re-execute completed steps`, `fast-forward a waitFor step`) are pre-existing flakes caused by vitest's 5s test timeout vs. retry backoff and reproduce on `main` without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)