### PR TITLE
refactor!: curate public exports for a focused DX

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -159,7 +159,7 @@ The context object passed to workflow handlers:
 
 `startWorkflow()` creates a top-level run and returns immediately. `step.invokeChildWorkflow()` starts a child run from inside a workflow, pauses the parent, and resolves with the child output when the child reaches a terminal state.
 
-`duration` is a string (e.g. `'3 days'`, `'2h'`) or an object (`{ weeks?, days?, hours?, minutes?, seconds? }`). See the `Duration` type and `parseDuration` from the package.
+`duration` is a string (e.g. `'3 days'`, `'2h'`) or an object (`{ weeks?, days?, hours?, minutes?, seconds? }`). See the `Duration` type exported from the package.
 
 ## WorkflowStatus
 

--- a/src/client.entry.ts
+++ b/src/client.entry.ts
@@ -1,12 +1,17 @@
+// Client-only entry: safe to import from API services without pulling in
+// the engine, the AST parser, or `pg` as a runtime dep.
+
 export type { StartWorkflowOptions, WorkflowClientOptions } from './client';
 export { WorkflowClient } from './client';
 export type { WorkflowRun } from './db/types';
 export { createWorkflowRef } from './definition';
+export { WorkflowEngineError, WorkflowRunNotFoundError } from './error';
 export type {
   InferInputParameters,
   InputParameters,
   WorkflowLogger,
   WorkflowRef,
+  WorkflowRunOptions,
   WorkflowRunProgress,
 } from './types';
 export { WorkflowStatus } from './types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,23 @@
-export * from './client';
-export * from './definition';
-export * from './duration';
-export * from './engine';
-export * from './error';
-export * from './types';
+// `WorkflowClient` is also available from `pg-workflows/client` for
+// client-only bundles that don't need engine or handler code.
+export type { StartWorkflowOptions, WorkflowClientOptions } from './client';
+export { WorkflowClient } from './client';
+export type { WorkflowRun } from './db/types';
+export { createWorkflowRef, workflow } from './definition';
+export type { Duration } from './duration';
+export { WorkflowEngine, type WorkflowEngineOptions } from './engine';
+export { WorkflowEngineError, WorkflowRunNotFoundError } from './error';
+export type {
+  InferInputParameters,
+  InputParameters,
+  StepBaseContext,
+  WorkflowContext,
+  WorkflowDefinition,
+  WorkflowLogger,
+  WorkflowOptions,
+  WorkflowPlugin,
+  WorkflowRef,
+  WorkflowRunOptions,
+  WorkflowRunProgress,
+} from './types';
+export { WorkflowStatus } from './types';


### PR DESCRIPTION
## Summary

- Replace blanket `export *` re-exports in `src/index.ts` and `src/client.entry.ts` with explicit, curated named exports.
- Drop internal helpers (`parseDuration`, `validateWorkflowId`, `validateResourceId`), internal types (`StepInternalDefinition`, `WorkflowInternalDefinition`, `WorkflowInternalLogger`, `WorkflowInternalLoggerContext`, `WorkflowFactory`, `DurationObject`), and the `StepType` enum from the public surface.
- Fix a missing export: `WorkflowRun` is now reachable from `pg-workflows` (was previously the return type of many engine methods but not importable).
- Round out `pg-workflows/client` with `WorkflowEngineError`, `WorkflowRunNotFoundError`, and `WorkflowRunOptions` — clients catch these and pass these.
- Remove a stale `parseDuration` mention from `docs/api-reference.md`.

### Final public surface

`pg-workflows` (main) and `pg-workflows/client` now export only:

- Functions: `workflow`, `createWorkflowRef`
- Classes: `WorkflowEngine` _(main only)_, `WorkflowClient`
- Errors: `WorkflowEngineError`, `WorkflowRunNotFoundError`
- Enum: `WorkflowStatus`
- Types: `WorkflowEngineOptions` _(main only)_, `WorkflowClientOptions`, `StartWorkflowOptions`, `WorkflowRun`, `WorkflowRunProgress`, `WorkflowRunOptions`, `WorkflowOptions`, `WorkflowContext` _(main only)_, `WorkflowDefinition` _(main only)_, `WorkflowRef`, `WorkflowPlugin` _(main only)_, `StepBaseContext` _(main only)_, `WorkflowLogger`, `InputParameters`, `InferInputParameters`, `Duration` _(main only)_

## Breaking change

The symbols listed above are no longer importable from `pg-workflows` or `pg-workflows/client`. Suggests a minor or major version bump on next release.

## Test plan

- [x] `npm run build` — succeeds, dist `.d.ts` shows only curated exports.
- [x] `npm run lint` — clean.
- [x] `npm run test:unit` — 121 passed, no type errors.
- [ ] `npm run test:integration` against a real PostgreSQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)