### PR TITLE
refactor!: rename WorkflowRunOptions to StartWorkflowOptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,7 +157,7 @@ const run = await engine.startWorkflow({
   resourceId: 'user-123',            // optional, for scoping/multi-tenancy
   input: { email: 'user@example.com' },
   idempotencyKey: 'unique-key-123',  // optional, for deduplication
-  options: { timeout, retries, expireInSeconds, batchSize }, // all optional
+  options: { timeout, retries, expireInSeconds }, // all optional
 });
 
 // Pause / Resume / Cancel

--- a/src/client.entry.ts
+++ b/src/client.entry.ts
@@ -1,7 +1,7 @@
 // Client-only entry: safe to import from API services without pulling in
 // the engine, the AST parser, or `pg` as a runtime dep.
 
-export type { StartWorkflowOptions, WorkflowClientOptions } from './client';
+export type { WorkflowClientOptions } from './client';
 export { WorkflowClient } from './client';
 export type { WorkflowRun } from './db/types';
 export { createWorkflowRef } from './definition';
@@ -9,9 +9,9 @@ export { WorkflowEngineError, WorkflowRunNotFoundError } from './error';
 export type {
   InferInputParameters,
   InputParameters,
+  StartWorkflowOptions,
   WorkflowLogger,
   WorkflowRef,
-  WorkflowRunOptions,
   WorkflowRunProgress,
 } from './types';
 export { WorkflowStatus } from './types';

--- a/src/client.ts
+++ b/src/client.ts
@@ -27,9 +27,9 @@ import {
 import {
   type InferInputParameters,
   type InputParameters,
+  type StartWorkflowOptions,
   type WorkflowLogger,
   type WorkflowRef,
-  type WorkflowRunOptions,
   type WorkflowRunProgress,
   WorkflowStatus,
 } from './types';
@@ -57,8 +57,6 @@ export type WorkflowClientOptions = {
    */
   boss?: PgBoss;
 } & ({ pool: pg.Pool; connectionString?: never } | { connectionString: string; pool?: never });
-
-export type StartWorkflowOptions = WorkflowRunOptions;
 
 const defaultLogger: WorkflowLogger = {
   log: (_message: string) => console.warn(_message),

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -31,6 +31,7 @@ import {
 import {
   type InferInputParameters,
   type InputParameters,
+  type StartWorkflowOptions,
   StepType,
   type WorkflowContext,
   type WorkflowDefinition,
@@ -39,18 +40,13 @@ import {
   type WorkflowInternalLoggerContext,
   type WorkflowLogger,
   type WorkflowRef,
-  type WorkflowRunOptions,
   type WorkflowRunProgress,
   WorkflowStatus,
 } from './types';
 
 const LOG_PREFIX = '[WorkflowEngine]';
 
-type StartWorkflowOptions = WorkflowRunOptions & {
-  batchSize?: number;
-};
-
-type ResolvedWorkflowRunParameters<TOptions extends WorkflowRunOptions = WorkflowRunOptions> = {
+type ResolvedWorkflowRunParameters<TOptions extends StartWorkflowOptions = StartWorkflowOptions> = {
   workflowId: string;
   input: unknown;
   resourceId?: string;
@@ -308,7 +304,7 @@ export class WorkflowEngine {
 
   private resolveWorkflowRunParameters<
     TInput extends InputParameters,
-    TOptions extends WorkflowRunOptions,
+    TOptions extends StartWorkflowOptions,
   >(
     refOrParams:
       | WorkflowRef<TInput, unknown>
@@ -380,7 +376,7 @@ export class WorkflowEngine {
       this.resolveWorkflowRunParameters(refOrParams, inputArg, optionsArg);
 
     if (!this._started) {
-      await this.start(false, { batchSize: options?.batchSize ?? 1 });
+      await this.start(false);
     }
 
     const { run } = await this.createWorkflowRun({
@@ -415,7 +411,7 @@ export class WorkflowEngine {
     input: unknown;
     resourceId?: string;
     idempotencyKey?: string;
-    options?: WorkflowRunOptions;
+    options?: StartWorkflowOptions;
     parentRunId?: string;
     parentStepId?: string;
     parentResourceId?: string;
@@ -1092,10 +1088,10 @@ export class WorkflowEngine {
                 input: unknown;
                 resourceId?: string;
                 idempotencyKey?: string;
-                options?: WorkflowRunOptions;
+                options?: StartWorkflowOptions;
               },
           inputArg?: InferInputParameters<TInput>,
-          optionsArg?: WorkflowRunOptions,
+          optionsArg?: StartWorkflowOptions,
         ) => {
           if (!run) {
             throw new WorkflowEngineError('Missing workflow run', workflowId, runId);
@@ -1332,7 +1328,7 @@ export class WorkflowEngine {
     input: unknown;
     resourceId?: string;
     idempotencyKey?: string;
-    options?: WorkflowRunOptions;
+    options?: StartWorkflowOptions;
   }): Promise<unknown> {
     let invokeOutput: unknown;
     let hasInvokeOutput = false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 // `WorkflowClient` is also available from `pg-workflows/client` for
 // client-only bundles that don't need engine or handler code.
-export type { StartWorkflowOptions, WorkflowClientOptions } from './client';
+export type { WorkflowClientOptions } from './client';
 export { WorkflowClient } from './client';
 export type { WorkflowRun } from './db/types';
 export { createWorkflowRef, workflow } from './definition';
@@ -10,6 +10,7 @@ export { WorkflowEngineError, WorkflowRunNotFoundError } from './error';
 export type {
   InferInputParameters,
   InputParameters,
+  StartWorkflowOptions,
   StepBaseContext,
   WorkflowContext,
   WorkflowDefinition,
@@ -17,7 +18,6 @@ export type {
   WorkflowOptions,
   WorkflowPlugin,
   WorkflowRef,
-  WorkflowRunOptions,
   WorkflowRunProgress,
 } from './types';
 export { WorkflowStatus } from './types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,7 +24,7 @@ export enum StepType {
 export type InputParameters = StandardSchemaV1;
 export type InferInputParameters<P extends InputParameters> = StandardSchemaV1.InferOutput<P>;
 
-export type WorkflowRunOptions = {
+export type StartWorkflowOptions = {
   resourceId?: string;
   timeout?: number;
   retries?: number;
@@ -74,7 +74,7 @@ export type StepBaseContext = {
       stepId: string,
       ref: WorkflowRef<TInput, TOutput>,
       input: InferInputParameters<TInput>,
-      options?: WorkflowRunOptions,
+      options?: StartWorkflowOptions,
     ): Promise<TOutput>;
     <TOutput = unknown>(
       stepId: string,
@@ -83,7 +83,7 @@ export type StepBaseContext = {
         input: unknown;
         resourceId?: string;
         idempotencyKey?: string;
-        options?: WorkflowRunOptions;
+        options?: StartWorkflowOptions;
       },
     ): Promise<TOutput>;
   };


### PR DESCRIPTION
## Summary
- Consolidates the two names for workflow-run options into a single canonical `StartWorkflowOptions`, aligned with the `startWorkflow()` method name for DX.
- Removes the `WorkflowRunOptions` alias and the redundant `export type StartWorkflowOptions = WorkflowRunOptions;` re-export.
- Drops the dead `batchSize` option on `engine.startWorkflow` — it was threaded into the auto-start path (`start(false, …)`) which skips worker creation, so it never had any effect.

## Breaking changes
- `WorkflowRunOptions` is renamed to `StartWorkflowOptions`. Consumers must update imports.
- `options.batchSize` on `engine.startWorkflow(...)` is removed (no-op previously).

## Test plan
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test:unit` (121 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)