### PR TITLE
chore: clear unregisteredWorkflows map after register loop on start()

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -200,6 +200,8 @@ export class WorkflowEngine {
       for (const workflow of this.unregisteredWorkflows.values()) {
         await this.registerWorkflow(workflow);
       }
+
+      this.unregisteredWorkflows.clear();
     }
 
     // pg-boss handles retries: every send sets retryLimit + retryBackoff


### PR DESCRIPTION
Closes #16

Clear the `unregisteredWorkflows` map on `start()` after we have registered them.