### PR TITLE
Refactor/extra engine types

### DIFF
--- a/src/ast-parser.test.ts
+++ b/src/ast-parser.test.ts
@@ -6,7 +6,7 @@ import { workflow } from './definition';
 import { WorkflowEngine } from './engine';
 import { getBoss } from './tests/pgboss';
 import { createTestDatabase } from './tests/test-db';
-import { StepType } from './types';
+import { type StepBaseContext, StepType } from './types';
 
 let testBoss: PgBoss;
 let testPool: pg.Pool;
@@ -328,5 +328,23 @@ describe('AST Parser for Workflow Steps', () => {
     await expect(engine.registerWorkflow(duplicateDynamicWorkflow)).rejects.toThrow(
       "Duplicate step ID detected: 'process-item'. Step IDs must be unique within a workflow.",
     );
+  });
+
+  it('does not catch externally defined workflow functions', async () => {
+    const workflowHandler = async (step: StepBaseContext, _input: unknown) => {
+      await step.run('process-item', async () => 'result-1');
+    };
+
+    const testWorkflow = workflow(
+      'parsing-will-not-work-at-this-workflow',
+      async ({ step, input }) => {
+        workflowHandler(step, input);
+      },
+    );
+
+    const engine = new WorkflowEngine({ pool: testPool, boss: testBoss });
+    await engine.registerWorkflow(testWorkflow);
+
+    expect(engine.workflows.get('parsing-will-not-work-at-this-workflow')?.steps).toEqual([]);
   });
 });

--- a/src/ast-parser.test.ts
+++ b/src/ast-parser.test.ts
@@ -1,6 +1,7 @@
 import type pg from 'pg';
 import type { PgBoss } from 'pg-boss';
 import { beforeAll, describe, expect, it } from 'vitest';
+import { z } from 'zod';
 import { workflow } from './definition';
 import { WorkflowEngine } from './engine';
 import { getBoss } from './tests/pgboss';
@@ -62,16 +63,20 @@ describe('AST Parser for Workflow Steps', () => {
   });
 
   it('should detect conditional steps', async () => {
-    const conditionalWorkflow = workflow('conditional-workflow', async ({ step, input }) => {
-      await step.run('step-1', async () => 'result-1');
+    const conditionalWorkflow = workflow(
+      'conditional-workflow',
+      async ({ step, input }) => {
+        await step.run('step-1', async () => 'result-1');
 
-      if (input.condition) {
-        await step.run('conditional-step', async () => 'conditional-result');
-      }
+        if (input.condition) {
+          await step.run('conditional-step', async () => 'conditional-result');
+        }
 
-      await step.run('step-3', async () => 'result-3');
-      return 'completed';
-    });
+        await step.run('step-3', async () => 'result-3');
+        return 'completed';
+      },
+      { inputSchema: z.object({ condition: z.boolean() }) },
+    );
 
     const engine = new WorkflowEngine({ pool: testPool, boss: testBoss });
     await engine.registerWorkflow(conditionalWorkflow);
@@ -199,53 +204,96 @@ describe('AST Parser for Workflow Steps', () => {
 
     const engine = new WorkflowEngine({ pool: testPool, boss: testBoss });
     await engine.registerWorkflow(mixedStepWorkflow);
+
+    expect(engine.workflows.get('mixed-step-workflow')?.steps).toEqual([
+      { id: 'step-1', type: StepType.RUN, conditional: false, loop: false, isDynamic: false },
+      { id: 'step-2', type: StepType.WAIT_FOR, conditional: false, loop: false, isDynamic: false },
+      { id: 'step-3', type: StepType.PAUSE, conditional: false, loop: false, isDynamic: false },
+      { id: 'step-4', type: StepType.RUN, conditional: false, loop: false, isDynamic: false },
+    ]);
   });
 
   it('should handle nested conditionals and loops', async () => {
-    const nestedWorkflow = workflow('nested-workflow', async ({ step, input }) => {
-      await step.run('start', async () => 'started');
+    const nestedWorkflow = workflow(
+      'nested-workflow',
+      async ({ step, input }) => {
+        await step.run('start', async () => 'started');
 
-      for (let i = 0; i < input.outerCount; i++) {
-        if (i % 2 === 0) {
-          await step.run(`even-${i}`, async () => `even-result-${i}`);
+        for (let i = 0; i < input.outerCount; i++) {
+          if (i % 2 === 0) {
+            await step.run(`even-${i}`, async () => `even-result-${i}`);
 
-          for (let j = 0; j < 2; j++) {
-            await step.run(`nested-${i}-${j}`, async () => `nested-result-${i}-${j}`);
+            for (let j = 0; j < 2; j++) {
+              await step.run(`nested-${i}-${j}`, async () => `nested-result-${i}-${j}`);
+            }
+          } else {
+            await step.run(`odd-${i}`, async () => `odd-result-${i}`);
           }
-        } else {
-          await step.run(`odd-${i}`, async () => `odd-result-${i}`);
         }
-      }
 
-      await step.run('end', async () => 'ended');
-      return 'completed';
-    });
+        await step.run('end', async () => 'ended');
+        return 'completed';
+      },
+      { inputSchema: z.object({ outerCount: z.number() }) },
+    );
 
     const engine = new WorkflowEngine({ pool: testPool, boss: testBoss });
     await engine.registerWorkflow(nestedWorkflow);
+
+    expect(engine.workflows.get('nested-workflow')?.steps).toEqual([
+      { id: 'start', type: StepType.RUN, conditional: false, loop: false, isDynamic: false },
+      { id: `even-\${...}`, type: StepType.RUN, conditional: true, loop: true, isDynamic: true },
+      {
+        id: `nested-\${...}-\${...}`,
+        type: StepType.RUN,
+        conditional: true,
+        loop: true,
+        isDynamic: true,
+      },
+      { id: `odd-\${...}`, type: StepType.RUN, conditional: true, loop: true, isDynamic: true },
+      { id: 'end', type: StepType.RUN, conditional: false, loop: false, isDynamic: false },
+    ]);
   });
 
   it('should handle switch statements', async () => {
-    const switchWorkflow = workflow('switch-workflow', async ({ step, input }) => {
-      await step.run('step-1', async () => 'result-1');
+    const switchWorkflow = workflow(
+      'switch-workflow',
+      async ({ step, input }) => {
+        await step.run('step-1', async () => 'result-1');
 
-      switch (input.type) {
-        case 'A':
-          await step.run('handle-a', async () => 'handled-a');
-          break;
-        case 'B':
-          await step.run('handle-b', async () => 'handled-b');
-          break;
-        default:
-          await step.run('handle-default', async () => 'handled-default');
-      }
+        switch (input.type) {
+          case 'A':
+            await step.run('handle-a', async () => 'handled-a');
+            break;
+          case 'B':
+            await step.run('handle-b', async () => 'handled-b');
+            break;
+          default:
+            await step.run('handle-default', async () => 'handled-default');
+        }
 
-      await step.run('step-3', async () => 'result-3');
-      return 'completed';
-    });
+        await step.run('step-3', async () => 'result-3');
+        return 'completed';
+      },
+      { inputSchema: z.object({ type: z.string() }) },
+    );
 
     const engine = new WorkflowEngine({ pool: testPool, boss: testBoss });
     await engine.registerWorkflow(switchWorkflow);
+
+    expect(engine.workflows.get('switch-workflow')?.steps).toEqual([
+      { id: 'step-1', type: StepType.RUN, conditional: false, loop: false, isDynamic: false },
+      { id: 'handle-a', type: StepType.RUN, conditional: true, loop: false, isDynamic: false },
+      { id: 'handle-b', type: StepType.RUN, conditional: true, loop: false, isDynamic: false },
+      {
+        id: 'handle-default',
+        type: StepType.RUN,
+        conditional: true,
+        loop: false,
+        isDynamic: false,
+      },
+      { id: 'step-3', type: StepType.RUN, conditional: false, loop: false, isDynamic: false },
+    ]);
   });
 
   it('should throw error for duplicate static step IDs', async () => {

--- a/src/ast-parser.test.ts
+++ b/src/ast-parser.test.ts
@@ -330,7 +330,7 @@ describe('AST Parser for Workflow Steps', () => {
     );
   });
 
-  it('does not catch externally defined workflow functions', async () => {
+  it('does not parse the steps of externally defined workflow functions', async () => {
     const workflowHandler = async (step: StepBaseContext, _input: unknown) => {
       await step.run('process-item', async () => 'result-1');
     };

--- a/src/ast-parser.ts
+++ b/src/ast-parser.ts
@@ -1,6 +1,6 @@
 import * as ts from 'typescript';
 import type { StepInternalDefinition, WorkflowContext } from './types';
-import { StepType } from './types';
+import { STEP_BASE_METHOD_TYPES } from './types';
 
 type ParseWorkflowHandlerReturnType = {
   steps: StepInternalDefinition[];
@@ -73,21 +73,11 @@ export function parseWorkflowHandler(
       const objectName = propertyAccess.expression.getText(sourceFile);
       const methodName = propertyAccess.name.text;
 
-      if (
-        objectName === 'step' &&
-        (methodName === 'run' ||
-          methodName === 'waitFor' ||
-          methodName === 'pause' ||
-          methodName === 'waitUntil' ||
-          methodName === 'delay' ||
-          methodName === 'sleep' ||
-          methodName === 'poll' ||
-          methodName === 'invokeChildWorkflow')
-      ) {
+      const stepType = objectName === 'step' ? STEP_BASE_METHOD_TYPES.get(methodName) : undefined;
+      if (stepType !== undefined) {
         const firstArg = node.arguments[0];
         if (firstArg) {
           const { id, isDynamic } = extractStepId(firstArg);
-          const stepType = methodName === 'sleep' ? StepType.DELAY : (methodName as StepType);
 
           const stepDefinition: StepInternalDefinition = {
             id,

--- a/src/db/migration.test.ts
+++ b/src/db/migration.test.ts
@@ -1,5 +1,5 @@
-import type { Db } from 'pg-boss';
 import type pg from 'pg';
+import type { Db } from 'pg-boss';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { closeTestDatabase, createTestDatabase } from '../tests/test-db';
 import { runMigrations } from './migration';

--- a/src/db/migration.test.ts
+++ b/src/db/migration.test.ts
@@ -1,0 +1,75 @@
+import type { Db } from 'pg-boss';
+import type pg from 'pg';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { closeTestDatabase, createTestDatabase } from '../tests/test-db';
+import { runMigrations } from './migration';
+
+const CURRENT_SCHEMA_VERSION = 5;
+
+describe('runMigrations', () => {
+  let pool: pg.Pool;
+  let db: Db;
+
+  beforeEach(async () => {
+    pool = await createTestDatabase();
+    db = {
+      executeSql: (text: string, values?: unknown[]) =>
+        pool.query(text, values) as Promise<{ rows: unknown[] }>,
+    };
+  });
+
+  afterEach(async () => {
+    await closeTestDatabase();
+  });
+
+  const tableExists = async (name: string): Promise<boolean> => {
+    const result = await db.executeSql(
+      `SELECT 1 FROM information_schema.tables
+       WHERE table_schema = current_schema() AND table_name = $1 LIMIT 1`,
+      [name],
+    );
+    return result.rows.length > 0;
+  };
+
+  const schemaVersion = async (): Promise<number> => {
+    const result = await db.executeSql('SELECT version FROM workflow_schema_version LIMIT 1', []);
+    return (result.rows[0] as { version: number }).version;
+  };
+
+  it('migrates a fresh database to the current schema version', async () => {
+    await runMigrations(db);
+
+    expect(await tableExists('workflow_runs')).toBe(true);
+    expect(await tableExists('workflow_schema_version')).toBe(true);
+    expect(await schemaVersion()).toBe(CURRENT_SCHEMA_VERSION);
+  });
+
+  it('is idempotent when run repeatedly', async () => {
+    await runMigrations(db);
+    await runMigrations(db); // second run hits the fast path, must not throw
+    await runMigrations(db);
+
+    expect(await schemaVersion()).toBe(CURRENT_SCHEMA_VERSION);
+  });
+
+  it('throws when a foreign workflow_runs table already exists', async () => {
+    // Simulate a consumer who already has their own unrelated workflow_runs table.
+    await db.executeSql('CREATE TABLE workflow_runs (id integer PRIMARY KEY, my_col text)', []);
+
+    await expect(runMigrations(db)).rejects.toThrow(
+      /already exists in this schema but was not created by pg-workflows/,
+    );
+
+    // The guard must fire before any DDL: no version table, and the foreign
+    // table must be left untouched (still has its original column).
+    expect(await tableExists('workflow_schema_version')).toBe(false);
+    const cols = await db.executeSql(
+      `SELECT column_name FROM information_schema.columns
+       WHERE table_schema = current_schema() AND table_name = 'workflow_runs'`,
+      [],
+    );
+    const columnNames = cols.rows.map((r) => (r as { column_name: string }).column_name);
+    expect(columnNames).toContain('my_col');
+    expect(columnNames).not.toContain('idempotency_key'); // proves no ALTER ran
+  });
+});

--- a/src/db/migration.ts
+++ b/src/db/migration.ts
@@ -24,17 +24,33 @@ export async function runMigrations(db: Db): Promise<void> {
   const commands: string[] = [];
 
   if (currentVersion < 1) {
-    // Check if a foreign `workflow_runs` already exists, if yes
-    // bail, in order to avoid corrupting existing tables
+    // On first run, we run a check to see if there is an existing foreign
+    // `workflow_runs` table. To decide on that, we check if the `workflow_runs`
+    // exists but a `workflow_schema_version` table doesn't. If that is true
+    // then `workflow_runs` is foreign and we should fail lest we start
+    // adding rows there, corrupting it.
+    // This is not airtight, but serves as an extra safety check for now.
     const existing = await db.executeSql(
-      `SELECT 1 FROM information_schema.tables
-      WHERE table_schema = current_schema() AND table_name = 'workflow_runs' LIMIT 1`,
+      `SELECT
+         to_regclass('workflow_runs') IS NOT NULL AS has_runs_table,
+         to_regclass('workflow_schema_version') IS NOT NULL AS has_version_table`,
       [],
     );
 
-    if (existing.rows.length > 0) {
+    const row = existing.rows[0] as
+      | { has_runs_table: boolean; has_version_table: boolean }
+      | undefined;
+
+    if (row?.has_runs_table && !row.has_version_table) {
       throw new Error(
         `pg-workflows: a "workflow_runs" table already exists in this schema but was not ` +
+          `created by pg-workflows. Point the workflow engine at a dedicated schema/database.`,
+      );
+    }
+
+    if (!row?.has_runs_table && row?.has_version_table) {
+      throw new Error(
+        `pg-workflows: a "workflow_schema_version" table already exists in this schema but was not ` +
           `created by pg-workflows. Point the workflow engine at a dedicated schema/database.`,
       );
     }

--- a/src/db/migration.ts
+++ b/src/db/migration.ts
@@ -28,7 +28,8 @@ export async function runMigrations(db: Db): Promise<void> {
     // `workflow_runs` table. To decide on that, we check if the `workflow_runs`
     // exists but a `workflow_schema_version` table doesn't. If that is true
     // then `workflow_runs` is foreign and we should fail lest we start
-    // adding rows there, corrupting it.
+    // adding rows there, corrupting it. We also do the reverse check.
+    // We are basing this off the fact that our transaction creates both or no tables
     // This is not airtight, but serves as an extra safety check for now.
     const existing = await db.executeSql(
       `SELECT

--- a/src/db/migration.ts
+++ b/src/db/migration.ts
@@ -24,6 +24,21 @@ export async function runMigrations(db: Db): Promise<void> {
   const commands: string[] = [];
 
   if (currentVersion < 1) {
+    // Check if a foreign `workflow_runs` already exists, if yes
+    // bail, in order to avoid corrupting existing tables
+    const existing = await db.executeSql(
+      `SELECT 1 FROM information_schema.tables
+      WHERE table_schema = current_schema() AND table_name = 'workflow_runs' LIMIT 1`,
+      [],
+    );
+
+    if (existing.rows.length > 0) {
+      throw new Error(
+        `pg-workflows: a "workflow_runs" table already exists in this schema but was not ` +
+          `created by pg-workflows. Point the workflow engine at a dedicated schema/database.`,
+      );
+    }
+
     commands.push(`
       CREATE TABLE IF NOT EXISTS workflow_runs (
         id varchar(32) PRIMARY KEY NOT NULL,

--- a/src/engine.test.ts
+++ b/src/engine.test.ts
@@ -1359,6 +1359,7 @@ describe('WorkflowEngine', () => {
         parentRunId: null,
         parentStepId: null,
         parentResourceId: null,
+        scheduledAt: null,
       };
       const lockedParentRun: WorkflowRun = {
         ...parentRun,
@@ -1420,6 +1421,7 @@ describe('WorkflowEngine', () => {
         parentRunId: null,
         parentStepId: null,
         parentResourceId: null,
+        scheduledAt: null,
       };
       const childRun: WorkflowRun = {
         id: 'invoke-child-resource-replay-run',
@@ -1444,6 +1446,7 @@ describe('WorkflowEngine', () => {
         parentRunId: parentRun.id,
         parentStepId: 'call-child',
         parentResourceId: resourceId,
+        scheduledAt: null,
       };
       const lockedParentRun: WorkflowRun = {
         ...parentRun,

--- a/src/engine.test.ts
+++ b/src/engine.test.ts
@@ -674,6 +674,94 @@ describe('WorkflowEngine', () => {
         expect(run2.idempotencyKey).toBe('test-key-1');
       });
 
+      it('reusing an idempotencyKey enqueues no second job and the first one is not affected', async () => {
+        const run1 = await engine.startWorkflow({
+          resourceId,
+          workflowId: 'test-workflow',
+          input: { data: 'hello' },
+          idempotencyKey: 'idem-noop',
+        });
+
+        await expect
+          .poll(async () => (await engine.getRun({ runId: run1.id, resourceId })).status)
+          .toBe(WorkflowStatus.COMPLETED);
+
+        const completedRun1 = await engine.getRun({ runId: run1.id, resourceId });
+
+        const sendSpy = vi.spyOn(testBoss, 'send');
+        try {
+          const run2 = await engine.startWorkflow({
+            resourceId,
+            workflowId: 'test-workflow',
+            input: { data: 'hello' },
+            idempotencyKey: 'idem-noop',
+          });
+
+          expect(run2.id).toBe(run1.id);
+          expect(sendSpy).not.toHaveBeenCalled();
+        } finally {
+          sendSpy.mockRestore();
+        }
+
+        const after = await engine.getRun({ runId: run1.id, resourceId });
+        expect(after.status).toBe(WorkflowStatus.COMPLETED);
+        expect(after.output).toEqual(completedRun1.output);
+        expect(after.updatedAt).toEqual(completedRun1.updatedAt);
+      });
+
+      it('reusing an idempotencyKey while the first run is mid-execution is a no-op and leaves it in-flight', async () => {
+        const wf = workflow('idem-midflight', async ({ step }) => {
+          await step.run('s1', async () => 'done-1');
+          await step.waitFor('gate', { eventName: 'go' });
+
+          return 'completed';
+        });
+
+        await engine.registerWorkflow(wf);
+
+        const run1 = await engine.startWorkflow({
+          resourceId,
+          workflowId: 'idem-midflight',
+          input: {},
+          idempotencyKey: 'idem-mid',
+        });
+
+        await expect
+          .poll(async () => (await engine.getRun({ runId: run1.id, resourceId })).status)
+          .toBe(WorkflowStatus.PAUSED);
+
+        const inflight = await engine.getRun({ runId: run1.id, resourceId });
+
+        const sendSpy = vi.spyOn(testBoss, 'send');
+        try {
+          const run2 = await engine.startWorkflow({
+            resourceId,
+            workflowId: 'idem-midflight',
+            input: {},
+            idempotencyKey: 'idem-mid',
+          });
+
+          expect(run2.id).toBe(run1.id);
+          expect(run2.status).toBe(WorkflowStatus.PAUSED);
+          expect(sendSpy).not.toHaveBeenCalled();
+        } finally {
+          sendSpy.mockRestore();
+        }
+
+        const after = await engine.getRun({ runId: run1.id, resourceId });
+        expect(after.timeline).toEqual(inflight.timeline);
+
+        expect(after.timeline).toMatchObject({
+          s1: { output: 'done-1' },
+          'gate-wait-for': { waitFor: { eventName: 'go' } },
+        });
+
+        await engine.triggerEvent({ runId: run1.id, resourceId, eventName: 'go' });
+        await expect
+          .poll(async () => (await engine.getRun({ runId: run1.id, resourceId })).status)
+          .toBe(WorkflowStatus.COMPLETED);
+      });
+
       it('should create two runs when no idempotencyKey is provided', async () => {
         const run1 = await engine.startWorkflow({
           resourceId,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -490,6 +490,22 @@ export class WorkflowEngine {
     return run;
   }
 
+  private async createChildWorkflowRun(params: {
+    workflowId: string;
+    input: unknown;
+    resourceId?: string;
+    idempotencyKey?: string;
+    options?: StartWorkflowOptions;
+    parentRunId: string;
+    parentStepId: string;
+    parentResourceId?: string;
+    scheduledAt?: Date;
+    enqueue?: boolean;
+    db?: Db;
+  }): Promise<{ run: WorkflowRun; created: boolean }> {
+    return this.createWorkflowRun(params);
+  }
+
   private async createWorkflowRun({
     workflowId,
     input,
@@ -1527,7 +1543,7 @@ export class WorkflowEngine {
           return;
         }
 
-        const result = await this.createWorkflowRun({
+        const result = await this.createChildWorkflowRun({
           workflowId,
           input,
           resourceId: childResourceId,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -35,6 +35,7 @@ import {
   type InferInputParameters,
   type InputParameters,
   type StartWorkflowOptions,
+  type StepBaseContext,
   StepType,
   type WorkflowContext,
   type WorkflowDefinition,
@@ -63,7 +64,7 @@ export type WorkflowEngineOptions = {
   boss?: PgBoss;
 } & ({ pool: pg.Pool; connectionString?: never } | { connectionString: string; pool?: never });
 
-const StepTypeToIcon = {
+const StepTypeToIcon: Record<StepType, string> = {
   [StepType.RUN]: 'λ',
   [StepType.WAIT_FOR]: '○',
   [StepType.PAUSE]: '⏸',
@@ -357,7 +358,7 @@ export class WorkflowEngine {
     this.workflows.set(definition.id, {
       ...definition,
       steps,
-    } as WorkflowInternalDefinition);
+    });
 
     if (this._started && resolvedSchedule) {
       await this.registerWorkflowSchedule(definition.id, resolvedSchedule);
@@ -1117,121 +1118,8 @@ export class WorkflowEngine {
         );
       }
 
-      const baseStep = {
-        run: async <T>(stepId: string, handler: () => Promise<T>) => {
-          if (!run) {
-            throw new WorkflowEngineError('Missing workflow run', workflowId, runId);
-          }
-          return this.runStep({ stepId, run, handler }) as Promise<T>;
-        },
-        waitFor: async <T extends InputParameters>(
-          stepId: string,
-          { eventName, timeout }: { eventName: string; timeout?: number; schema?: T },
-        ) => {
-          if (!run) {
-            throw new WorkflowEngineError('Missing workflow run', workflowId, runId);
-          }
-          const timeoutDate = timeout ? new Date(Date.now() + timeout) : undefined;
-          return this.waitStep({ run, stepId, eventName, timeoutDate }) as Promise<
-            InferInputParameters<T> | undefined
-          >;
-        },
-        waitUntil: async (
-          stepId: string,
-          dateOrOptions: Date | string | { date: Date | string },
-        ) => {
-          if (!run) {
-            throw new WorkflowEngineError('Missing workflow run', workflowId, runId);
-          }
-          const date =
-            dateOrOptions instanceof Date
-              ? dateOrOptions
-              : typeof dateOrOptions === 'string'
-                ? new Date(dateOrOptions)
-                : dateOrOptions.date instanceof Date
-                  ? dateOrOptions.date
-                  : new Date(dateOrOptions.date);
-          await this.waitStep({ run, stepId, timeoutDate: date });
-        },
-        pause: async (stepId: string) => {
-          if (!run) {
-            throw new WorkflowEngineError('Missing workflow run', workflowId, runId);
-          }
-          await this.waitStep({ run, stepId, eventName: PAUSE_EVENT_NAME });
-        },
-        delay: async (stepId: string, duration: Duration) => {
-          if (!run) {
-            throw new WorkflowEngineError('Missing workflow run', workflowId, runId);
-          }
-          await this.waitStep({
-            run,
-            stepId,
-            timeoutDate: new Date(Date.now() + parseDuration(duration)),
-          });
-        },
-        get sleep() {
-          return this.delay;
-        },
-        poll: async <T>(
-          stepId: string,
-          conditionFn: () => Promise<T | false>,
-          options?: { interval?: Duration; timeout?: Duration },
-        ) => {
-          if (!run) {
-            throw new WorkflowEngineError('Missing workflow run', workflowId, runId);
-          }
-          const intervalMs = parseDuration(options?.interval ?? '30s');
-          if (intervalMs < 30_000) {
-            throw new WorkflowEngineError(
-              `step.poll interval must be at least 30s (got ${intervalMs}ms)`,
-              workflowId,
-              runId,
-            );
-          }
-          const timeoutMs = options?.timeout ? parseDuration(options.timeout) : undefined;
-          return this.pollStep({ run, stepId, conditionFn, intervalMs, timeoutMs }) as Promise<
-            { timedOut: false; data: T } | { timedOut: true }
-          >;
-        },
-        invokeChildWorkflow: async <TInput extends InputParameters, TOutput = unknown>(
-          stepId: string,
-          refOrParams:
-            | WorkflowRef<TInput, TOutput>
-            | {
-                workflowId: string;
-                input: unknown;
-                resourceId?: string;
-                idempotencyKey?: string;
-                options?: StartWorkflowOptions;
-              },
-          inputArg?: InferInputParameters<TInput>,
-          optionsArg?: StartWorkflowOptions,
-        ) => {
-          if (!run) {
-            throw new WorkflowEngineError('Missing workflow run', workflowId, runId);
-          }
+      let step = this.createBaseStep(run, workflowId, runId);
 
-          // Resolve overload input (typed ref or params object) into one shape
-          // before handing off to the durable child-invocation implementation.
-          const resolvedChildCall = this.resolveWorkflowRunParameters(
-            refOrParams,
-            inputArg,
-            optionsArg,
-          );
-          const childWorkflowInvocation = {
-            run,
-            stepId,
-            workflowId: resolvedChildCall.workflowId,
-            input: resolvedChildCall.input,
-            options: resolvedChildCall.options,
-            resourceId: resolvedChildCall.resourceId,
-            idempotencyKey: resolvedChildCall.idempotencyKey,
-          };
-          return this.invokeChildWorkflowStep(childWorkflowInvocation) as Promise<TOutput>;
-        },
-      };
-
-      let step = { ...baseStep };
       const plugins = workflow.plugins ?? [];
 
       const context: WorkflowContext = {
@@ -1348,6 +1236,100 @@ export class WorkflowEngine {
       runId,
       workflowId: run.workflowId,
     });
+  }
+
+  private createBaseStep(run: WorkflowRun, workflowId: string, runId: string): StepBaseContext {
+    return {
+      run: async <T>(stepId: string, handler: () => Promise<T>) => {
+        return this.runStep({ stepId, run, handler }) as Promise<T>;
+      },
+      waitFor: async <T extends InputParameters>(
+        stepId: string,
+        { eventName, timeout }: { eventName: string; timeout?: number; schema?: T },
+      ) => {
+        const timeoutDate = timeout ? new Date(Date.now() + timeout) : undefined;
+
+        return this.waitStep({ run, stepId, eventName, timeoutDate }) as Promise<
+          InferInputParameters<T> | undefined
+        >;
+      },
+      waitUntil: async (stepId: string, dateOrOptions: Date | string | { date: Date | string }) => {
+        const date =
+          dateOrOptions instanceof Date
+            ? dateOrOptions
+            : typeof dateOrOptions === 'string'
+              ? new Date(dateOrOptions)
+              : dateOrOptions.date instanceof Date
+                ? dateOrOptions.date
+                : new Date(dateOrOptions.date);
+        await this.waitStep({ run, stepId, timeoutDate: date });
+      },
+      pause: async (stepId: string) => {
+        await this.waitStep({ run, stepId, eventName: PAUSE_EVENT_NAME });
+      },
+      delay: async (stepId: string, duration: Duration) => {
+        await this.waitStep({
+          run,
+          stepId,
+          timeoutDate: new Date(Date.now() + parseDuration(duration)),
+        });
+      },
+      get sleep() {
+        return this.delay;
+      },
+      poll: async <T>(
+        stepId: string,
+        conditionFn: () => Promise<T | false>,
+        options?: { interval?: Duration; timeout?: Duration },
+      ) => {
+        const intervalMs = parseDuration(options?.interval ?? '30s');
+        if (intervalMs < 30_000) {
+          throw new WorkflowEngineError(
+            `step.poll interval must be at least 30s (got ${intervalMs}ms)`,
+            workflowId,
+            runId,
+          );
+        }
+        const timeoutMs = options?.timeout ? parseDuration(options.timeout) : undefined;
+
+        return this.pollStep({ run, stepId, conditionFn, intervalMs, timeoutMs }) as Promise<
+          { timedOut: false; data: T } | { timedOut: true }
+        >;
+      },
+      invokeChildWorkflow: async <TInput extends InputParameters, TOutput = unknown>(
+        stepId: string,
+        refOrParams:
+          | WorkflowRef<TInput, TOutput>
+          | {
+              workflowId: string;
+              input: unknown;
+              resourceId?: string;
+              idempotencyKey?: string;
+              options?: StartWorkflowOptions;
+            },
+        inputArg?: InferInputParameters<TInput>,
+        optionsArg?: StartWorkflowOptions,
+      ) => {
+        // Resolve overload input (typed ref or params object) into one shape
+        // before handing off to the durable child-invocation implementation.
+        const resolvedChildCall = this.resolveWorkflowRunParameters(
+          refOrParams,
+          inputArg,
+          optionsArg,
+        );
+        const childWorkflowInvocation = {
+          run,
+          stepId,
+          workflowId: resolvedChildCall.workflowId,
+          input: resolvedChildCall.input,
+          options: resolvedChildCall.options,
+          resourceId: resolvedChildCall.resourceId,
+          idempotencyKey: resolvedChildCall.idempotencyKey,
+        };
+
+        return this.invokeChildWorkflowStep(childWorkflowInvocation) as Promise<TOutput>;
+      },
+    };
   }
 
   private getCachedStepEntry(

--- a/src/types.ts
+++ b/src/types.ts
@@ -216,7 +216,23 @@ export type WorkflowInternalLoggerContext = {
   runId?: string;
   workflowId?: string;
 };
+
 export interface WorkflowInternalLogger {
   log(message: string, context?: WorkflowInternalLoggerContext): void;
   error(message: string, error: Error, context?: WorkflowInternalLoggerContext): void;
 }
+
+const _STEP_BASE_METHOD_TO_TYPE: Record<keyof StepBaseContext, StepType> = {
+  run: StepType.RUN,
+  waitFor: StepType.WAIT_FOR,
+  waitUntil: StepType.WAIT_UNTIL,
+  delay: StepType.DELAY,
+  sleep: StepType.DELAY,
+  pause: StepType.PAUSE,
+  poll: StepType.POLL,
+  invokeChildWorkflow: StepType.INVOKE_CHILD_WORKFLOW,
+};
+
+export const STEP_BASE_METHOD_TYPES: ReadonlyMap<string, StepType> = new Map(
+  Object.entries(_STEP_BASE_METHOD_TO_TYPE),
+);


### PR DESCRIPTION
## Parser detection driven by the type (`types.ts` + `ast-parser.ts`)

The AST parser's list of recognized `step.*` methods was maintained by hand,
disconnected from the actual step API (`StepBaseContext`). That let the two drift,
and the name→`StepType` mapping relied on an unchecked `as StepType` cast plus a
special-case `sleep` branch.

- Added `STEP_BASE_METHOD_TYPES`, derived from
  `_STEP_BASE_METHOD_TO_TYPE: Record<keyof StepBaseContext, StepType>`. The
  `Record<keyof StepBaseContext, …>` annotation makes the compiler enforce two
  things: every step method is mapped (add a method to `StepBaseContext` →
  compile error until it's in the map), and every value is a real `StepType`.
- The parser's `||` chain of method-name comparisons + `as StepType` cast +
  `sleep`-alias ternary collapse into a single `STEP_BASE_METHOD_TYPES.get(methodName)`
  lookup. `undefined` doubles as the "not a step method" check, and the
  `sleep → DELAY` alias is now data in the map rather than a branch in the parser.

## Engine type-safety & structure (`engine.ts`)

- Typed `StepTypeToIcon` as `Record<StepType, string>` so a new `StepType` forces
  a matching icon entry.
- Removed a redundant `as WorkflowInternalDefinition` cast on the
  `workflows.set(...)` literal. The spread already produces the correct type, and
  the cast was suppressing excess-property checking (stray keys are now caught).
- Extracted the ~110-line `baseStep` object literal out of `handleWorkflowRun`
  into a private `createBaseStep(run, workflowId, runId)` method.
- Added a private `createChildWorkflowRun(...)` that wraps `createWorkflowRun`
  with `parentRunId`/`parentStepId` **required** at the type level, so the
  child-invocation path can't be wired up without parent linkage.

## Fail loudly on a foreign `workflow_runs` table (`migration.ts`)

Previously, if a consumer already had a `workflow_runs` table in the target
schema, migrations could `ALTER`/index a table pg-workflows didn't create. The
migration now checks (only on a fresh install, i.e. no `workflow_schema_version`)
whether a `workflow_runs` table already exists and **throws a clear error**
pointing the user at a dedicated schema/rename — before any DDL runs.

This is the one behavioral change in the PR; it only fires for genuine collisions
and is otherwise inert (healthy installs are already past version 0).

## Test coverage

- **Parser** (`ast-parser.test.ts`): added real `expect(...).toEqual(...)`
  assertions to the previously no-assert `switch`, nested conditional/loop, and
  mixed-step tests; added a test documenting the known limitation that
  externally-defined handlers aren't parsed (yields `[]` steps).
- **Migration** (`migration.test.ts`, new): fresh DB migrates to the current
  version; migrations are idempotent across repeated runs; a foreign
  `workflow_runs` table makes `runMigrations` throw without touching it.
- **Idempotency** (`engine.test.ts`): reusing an `idempotencyKey` enqueues no
  second job and leaves the first run untouched (completed case); and the same
  holds while the first run is still mid-execution (paused) — the duplicate is a
  no-op and the in-flight run is undisturbed.

## Testing

- `tsc --noEmit` clean
- Full unit suite passes (parser, engine, definition, migration)
