### PR TITLE
bug/enforce workflow timeout_at (closes #17)

### DIFF
--- a/src/engine.test.ts
+++ b/src/engine.test.ts
@@ -8,6 +8,7 @@ import type { WorkflowRun } from './db/types';
 import { workflow } from './definition';
 import { WorkflowEngine } from './engine';
 import { WorkflowEngineError, WorkflowRunNotFoundError } from './error';
+import { metaWorkflowsKeys } from './meta-workflows';
 import { getBoss } from './tests/pgboss';
 import { closeTestDatabase, createTestDatabase } from './tests/test-db';
 import type { StepBaseContext, WorkflowPlugin } from './types';
@@ -15,6 +16,10 @@ import { WorkflowStatus } from './types';
 
 let testBoss: PgBoss;
 let testPool: pg.Pool;
+
+const disableDefaults = {
+  disabled: Object.values(metaWorkflowsKeys) as metaWorkflowsKeys[],
+};
 
 beforeAll(async () => {
   testPool = await createTestDatabase();
@@ -50,6 +55,7 @@ describe('WorkflowEngine', () => {
         workflows: [testWorkflow],
         pool: testPool,
         boss: testBoss,
+        defaultWorkflowOptions: disableDefaults,
       });
     });
 
@@ -82,6 +88,7 @@ describe('WorkflowEngine', () => {
         workflows: [testWorkflow],
         pool: testPool,
         boss: testBoss,
+        defaultWorkflowOptions: disableDefaults,
       });
       await engine.start(false);
     });
@@ -242,6 +249,7 @@ describe('WorkflowEngine', () => {
         ],
         pool: testPool,
         boss: testBoss,
+        defaultWorkflowOptions: disableDefaults,
       });
       await engine.start(false);
     });
@@ -323,6 +331,7 @@ describe('WorkflowEngine', () => {
         workflows: [],
         pool: testPool,
         boss: testBoss,
+        defaultWorkflowOptions: disableDefaults,
       });
       await engine.start();
 
@@ -363,6 +372,7 @@ describe('WorkflowEngine', () => {
         workflows: [],
         pool: testPool,
         boss: testBoss,
+        defaultWorkflowOptions: disableDefaults,
       });
       await engine.start();
 
@@ -423,7 +433,12 @@ describe('WorkflowEngine', () => {
         },
       };
 
-      const engine = new WorkflowEngine({ workflows: [], pool: testPool, boss: testBoss });
+      const engine = new WorkflowEngine({
+        workflows: [],
+        pool: testPool,
+        boss: testBoss,
+        defaultWorkflowOptions: disableDefaults,
+      });
       await engine.start();
 
       const wrapped = workflow.use(outerPlugin).use(innerPlugin)(
@@ -462,6 +477,7 @@ describe('WorkflowEngine', () => {
         workflows: [testWorkflow],
         pool: testPool,
         boss: testBoss,
+        defaultWorkflowOptions: disableDefaults,
       });
       await engine.start(false);
     });
@@ -484,6 +500,7 @@ describe('WorkflowEngine', () => {
         workflows: [testWorkflow],
         pool: testPool,
         boss: testBoss,
+        defaultWorkflowOptions: disableDefaults,
       });
       await engine.start(false);
     });
@@ -506,6 +523,7 @@ describe('WorkflowEngine', () => {
         workflows: [testWorkflow],
         pool: testPool,
         boss: testBoss,
+        defaultWorkflowOptions: disableDefaults,
       });
       await engine.start();
     });
@@ -864,6 +882,7 @@ describe('WorkflowEngine', () => {
         workflows: [testWorkflow],
         pool: testPool,
         boss: testBoss,
+        defaultWorkflowOptions: disableDefaults,
       });
       await engine.start();
     });
@@ -931,6 +950,7 @@ describe('WorkflowEngine', () => {
         workflows: [testWorkflow],
         pool: testPool,
         boss: testBoss,
+        defaultWorkflowOptions: disableDefaults,
       });
       await engine.start();
     });
@@ -986,6 +1006,7 @@ describe('WorkflowEngine', () => {
         workflows: [testWorkflow],
         pool: testPool,
         boss: testBoss,
+        defaultWorkflowOptions: disableDefaults,
       });
       await engine.start(false);
     });
@@ -1030,6 +1051,7 @@ describe('WorkflowEngine', () => {
         workflows: [testWorkflow],
         pool: testPool,
         boss: testBoss,
+        defaultWorkflowOptions: disableDefaults,
       });
       await engine2.start();
 
@@ -1061,6 +1083,7 @@ describe('WorkflowEngine', () => {
         workflows: [testWorkflow],
         pool: testPool,
         boss: testBoss,
+        defaultWorkflowOptions: disableDefaults,
       });
       await engine.start();
     });
@@ -2882,6 +2905,7 @@ describe('WorkflowEngine', () => {
         workflows: [testWorkflow],
         pool: testPool,
         boss: testBoss,
+        defaultWorkflowOptions: disableDefaults,
       });
       await engine.start(false);
     });
@@ -3090,6 +3114,7 @@ describe('WorkflowEngine', () => {
         workflows: [testWorkflow],
         pool: testPool,
         boss: testBoss,
+        defaultWorkflowOptions: disableDefaults,
       });
       await engine.start();
     });
@@ -3389,6 +3414,120 @@ describe('WorkflowEngine', () => {
             'wait-step': { output: {} },
             'step-2': { output: { prev: {} } },
           },
+        });
+    });
+  });
+
+  describe('default workflows', () => {
+    let engine: WorkflowEngine;
+
+    afterEach(async () => {
+      await engine.stop();
+    });
+
+    it('registers built-in default workflows on start', async () => {
+      engine = new WorkflowEngine({ workflows: [], pool: testPool, boss: testBoss });
+      await engine.start(false);
+
+      expect(engine.workflows.has(metaWorkflowsKeys.ScheduledCleanUpByTimeout)).toBe(true);
+    });
+
+    it('skips a default workflow listed in defaultWorkflowOptions.disabled', async () => {
+      engine = new WorkflowEngine({
+        workflows: [],
+        pool: testPool,
+        boss: testBoss,
+        defaultWorkflowOptions: {
+          disabled: [metaWorkflowsKeys.ScheduledCleanUpByTimeout],
+        },
+      });
+      await engine.start(false);
+
+      expect(engine.workflows.has(metaWorkflowsKeys.ScheduledCleanUpByTimeout)).toBe(false);
+    });
+
+    it('applies a per-workflow config override to a default workflow', async () => {
+      engine = new WorkflowEngine({
+        workflows: [],
+        pool: testPool,
+        boss: testBoss,
+        defaultWorkflowOptions: {
+          configs: {
+            [metaWorkflowsKeys.ScheduledCleanUpByTimeout]: { schedule: '30m' },
+          },
+        },
+      });
+      await engine.start(false);
+
+      expect(engine.workflows.get(metaWorkflowsKeys.ScheduledCleanUpByTimeout)?.schedule).toBe(
+        '30m',
+      );
+    });
+  });
+
+  describe('default workflow: timeout reaper', () => {
+    // Defaults ENABLED here — we want the built-in reaper registered so we can
+    // drive it and assert its cross-feature behaviour.
+    let engine: WorkflowEngine;
+
+    beforeEach(async () => {
+      engine = new WorkflowEngine({ workflows: [], pool: testPool, boss: testBoss });
+      await engine.start();
+    });
+
+    afterEach(async () => {
+      await engine.stop();
+    });
+
+    it('fails a parent when its invoked child is reaped by timeout', async () => {
+      const child = workflow(
+        'reaped-child',
+        async ({ step }) => {
+          await step.waitFor('never', { eventName: 'never-arrives' });
+          return { ok: true };
+        },
+        // Tiny timeout → timeout_at is effectively already in the past, so the
+        // reaper's `timeout_at < NOW()` matches on its next run.
+        { timeout: 1 },
+      );
+      const parent = workflow('reaped-parent', async ({ step }) => {
+        return await step.invokeChildWorkflow('call-child', {
+          workflowId: 'reaped-child',
+          input: {},
+        });
+      });
+
+      await engine.registerWorkflow(child);
+      await engine.registerWorkflow(parent);
+
+      const parentRun = await engine.startWorkflow({
+        resourceId,
+        workflowId: 'reaped-parent',
+        input: {},
+      });
+
+      // Parent pauses waiting on the child; the child pauses on its waitFor with
+      // an already-expired timeout_at.
+      await expect
+        .poll(async () => (await engine.getRun({ runId: parentRun.id, resourceId })).status)
+        .toBe(WorkflowStatus.PAUSED);
+
+      // Drive the reaper directly (its real schedule only fires every 10m).
+      await engine.startWorkflow({
+        workflowId: metaWorkflowsKeys.ScheduledCleanUpByTimeout,
+        input: {},
+      });
+
+      // The reaper fails the child and notifies the parent, which then fails
+      // with the child's error. This is the dropped-side-effect (parent
+      // notification) that this cross-feature test guards.
+      await expect
+        .poll(async () => await engine.getRun({ runId: parentRun.id, resourceId }), {
+          timeout: 15_000,
+        })
+        .toMatchObject({
+          status: WorkflowStatus.FAILED,
+          error: expect.stringContaining('Child workflow'),
         });
     });
   });

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -8,9 +8,9 @@ import {
   isInvokeChildWorkflowTimelineEntry,
   PAUSE_EVENT_NAME,
   scheduleQueueNameFor,
+  waitForTimelineKey,
   WORKFLOW_RUN_DLQ_QUEUE_NAME,
   WORKFLOW_RUN_QUEUE_NAME,
-  waitForTimelineKey,
 } from './constants';
 import { runMigrations } from './db/migration';
 import {
@@ -30,6 +30,7 @@ import {
   WorkflowEngineError,
   WorkflowRunNotFoundError,
 } from './error';
+import { type DefaultWorkflowOptions, defaultWorkflows } from './meta-workflows';
 import { resolveSchedule } from './schedule';
 import {
   type InferInputParameters,
@@ -62,6 +63,7 @@ export type WorkflowEngineOptions = {
   workflows?: WorkflowDefinition[];
   logger?: WorkflowLogger;
   boss?: PgBoss;
+  defaultWorkflowOptions?: DefaultWorkflowOptions;
 } & ({ pool: pg.Pool; connectionString?: never } | { connectionString: string; pool?: never });
 
 const StepTypeToIcon: Record<StepType, string> = {
@@ -152,7 +154,13 @@ export class WorkflowEngine {
   >();
   private logger: WorkflowInternalLogger;
 
-  constructor({ workflows, logger, boss, ...connectionOptions }: WorkflowEngineOptions) {
+  constructor({
+    workflows,
+    logger,
+    boss,
+    defaultWorkflowOptions,
+    ...connectionOptions
+  }: WorkflowEngineOptions) {
     this.logger = this.buildLogger(logger ?? defaultLogger);
 
     if ('pool' in connectionOptions && connectionOptions.pool) {
@@ -162,10 +170,6 @@ export class WorkflowEngine {
       this._ownsPool = true;
     } else {
       throw new WorkflowEngineError('Either pool or connectionString must be provided');
-    }
-
-    if (workflows) {
-      this.unregisteredWorkflows = new Map(workflows.map((workflow) => [workflow.id, workflow]));
     }
 
     const db: Db = {
@@ -179,6 +183,12 @@ export class WorkflowEngine {
       this.boss = new PgBoss({ db, schema: DEFAULT_PGBOSS_SCHEMA });
     }
     this.db = this.boss.getDb();
+
+    const defaults = defaultWorkflows(this, this.db, defaultWorkflowOptions);
+
+    this.unregisteredWorkflows = new Map(
+      [...(workflows ?? []), ...defaults].map((workflow) => [workflow.id, workflow]),
+    );
   }
 
   async start(

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -633,7 +633,9 @@ export class WorkflowEngine {
     });
   }
 
-  private async notifyParentOfChildTerminalRun(childRun: WorkflowRun) {
+  async notifyParentOfChildTerminalRun(
+    childRun: Pick<WorkflowRun, 'id' | 'parentRunId' | 'parentStepId' | 'parentResourceId'>,
+  ): Promise<void> {
     if (!childRun.parentRunId || !childRun.parentStepId) {
       return;
     }

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -8,9 +8,9 @@ import {
   isInvokeChildWorkflowTimelineEntry,
   PAUSE_EVENT_NAME,
   scheduleQueueNameFor,
-  waitForTimelineKey,
   WORKFLOW_RUN_DLQ_QUEUE_NAME,
   WORKFLOW_RUN_QUEUE_NAME,
+  waitForTimelineKey,
 } from './constants';
 import { runMigrations } from './db/migration';
 import {

--- a/src/meta-workflows/index.ts
+++ b/src/meta-workflows/index.ts
@@ -1,0 +1,55 @@
+import type { Db } from 'pg-boss';
+import type { WorkflowEngine } from '../engine';
+import type { Schedule } from '../schedule';
+import type { InputParameters, WorkflowDefinition } from '../types';
+import scheduledCleanUpByTimeout from './scheduled-clean-up-by-timeout';
+
+export enum metaWorkflowsKeys {
+  ScheduledCleanUpByTimeout = '__pgw-scheduled-clean-up-by-timeout',
+}
+
+export type DefaultWorkflowOptions = {
+  configs?: Partial<MetaWorkflowConfigMap>;
+  disabled?: metaWorkflowsKeys[];
+};
+
+export interface ScheduledCleanUpByTimeoutConfig {
+  maxPagesPerRun?: number;
+  schedule?: Schedule;
+  retries?: number;
+}
+
+interface MetaWorkflowConfigMap {
+  [metaWorkflowsKeys.ScheduledCleanUpByTimeout]: ScheduledCleanUpByTimeoutConfig;
+}
+
+type MetaWorkflowFactory<C> = (
+  engine: WorkflowEngine,
+  db: Db,
+  config?: C,
+) => WorkflowDefinition<InputParameters>;
+
+export const metaWorkflows: {
+  [K in metaWorkflowsKeys]: MetaWorkflowFactory<MetaWorkflowConfigMap[K]>;
+} = {
+  '__pgw-scheduled-clean-up-by-timeout': scheduledCleanUpByTimeout,
+};
+
+/**
+ *
+ * @param engine The workflow engine instance
+ * @param db The pg-boss db handler
+ * @param param2 optional configuration overrides for default workflows
+ * @returns Workflows by default registered doing meta work. e.g. scheduled clean up of expired workflow runs
+ */
+export const defaultWorkflows = (
+  engine: WorkflowEngine,
+  db: Db,
+  { configs = {}, disabled = [] }: DefaultWorkflowOptions = {},
+): WorkflowDefinition<InputParameters>[] => {
+  const enabled = (Object.keys(metaWorkflows) as metaWorkflowsKeys[]).filter(
+    (w) => !disabled.includes(w),
+  );
+
+  return enabled.map((k) => metaWorkflows[k](engine, db, configs[k]));
+};

--- a/src/meta-workflows/scheduled-clean-up-by-timeout.ts
+++ b/src/meta-workflows/scheduled-clean-up-by-timeout.ts
@@ -1,8 +1,8 @@
 import type { Db } from 'pg-boss';
-import type { ScheduledCleanUpByTimeoutConfig } from '.';
 import { workflow } from '../definition';
 import type { WorkflowEngine } from '../engine';
 import type { InputParameters, WorkflowDefinition } from '../types';
+import type { ScheduledCleanUpByTimeoutConfig } from '.';
 
 const PAGE = 100;
 const DEFAULT_CONFIG = { schedule: '10m', retries: 3, maxPagesPerRun: 10 };
@@ -65,6 +65,7 @@ const scheduledCleanUpByTimeout: (
               });
             }
           }
+
           return { selected: ids.length, cleaned: updated.rows.length };
         });
 

--- a/src/meta-workflows/scheduled-clean-up-by-timeout.ts
+++ b/src/meta-workflows/scheduled-clean-up-by-timeout.ts
@@ -1,0 +1,76 @@
+import type { Db } from 'pg-boss';
+import type { ScheduledCleanUpByTimeoutConfig } from '.';
+import { workflow } from '../definition';
+import type { WorkflowEngine } from '../engine';
+import type { InputParameters, WorkflowDefinition } from '../types';
+
+const PAGE = 100;
+const DEFAULT_CONFIG = { schedule: '10m', retries: 3, maxPagesPerRun: 10 };
+
+const selectExpiredWorkflowsByTimeoutPage = `
+    SELECT id FROM workflow_runs WHERE status IN ('running', 'paused') AND timeout_at < NOW() LIMIT ${PAGE}
+`;
+
+const scheduledCleanUpByTimeout: (
+  e: WorkflowEngine,
+  db: Db,
+  config?: ScheduledCleanUpByTimeoutConfig,
+) => WorkflowDefinition<InputParameters> = (_engine, db, config) =>
+  workflow(
+    '__pgw-scheduled-clean-up-by-timeout',
+    async ({ step, logger }) => {
+      logger.log(`Scheduled clean up of expired workflows...`);
+
+      const maxPagesPerRun = config?.maxPagesPerRun ?? DEFAULT_CONFIG.maxPagesPerRun;
+
+      let totalCleaned = 0;
+      let page = 0;
+      let drained = false;
+
+      while (page < maxPagesPerRun) {
+        const cleanUpAPageResult = await step.run(`clean-page-${page}`, async () => {
+          const expired = await db.executeSql(selectExpiredWorkflowsByTimeoutPage);
+          const rows = expired.rows as { id: string }[];
+          const ids = rows.map((r) => r.id);
+
+          if (ids.length === 0) return { cleaned: 0 };
+
+          const updated = await db.executeSql(
+            `UPDATE workflow_runs
+             SET status = 'failed', error = COALESCE(error, 'Workflow run timed out'), updated_at = NOW()
+             WHERE id = ANY($1)
+             RETURNING id`,
+            [ids],
+          );
+
+          return { cleaned: updated.rows.length };
+        });
+
+        totalCleaned += cleanUpAPageResult.cleaned;
+
+        if (cleanUpAPageResult.cleaned < PAGE) {
+          drained = true;
+          break;
+        }
+
+        page++;
+      }
+
+      return await step.run('clean-up-done', async () => {
+        logger.log(
+          `Clean up run finished. Cleaned ${totalCleaned}.` +
+            (drained
+              ? ''
+              : ' Max pages per run limit hit; remaining runs will be cleaned on the next fire.'),
+        );
+
+        return { totalCleaned };
+      });
+    },
+    {
+      schedule: config?.schedule ?? DEFAULT_CONFIG.schedule,
+      retries: config?.retries ?? DEFAULT_CONFIG.retries,
+    },
+  );
+
+export default scheduledCleanUpByTimeout;

--- a/src/meta-workflows/scheduled-clean-up-by-timeout.ts
+++ b/src/meta-workflows/scheduled-clean-up-by-timeout.ts
@@ -11,11 +11,16 @@ const selectExpiredWorkflowsByTimeoutPage = `
     SELECT id FROM workflow_runs WHERE status IN ('running', 'paused') AND timeout_at < NOW() LIMIT ${PAGE}
 `;
 
+/**
+ * This meta workflow is registered by the engine's constructor and runs on a schedule.
+ * Every time it runs, it checks for workflow runs that have explicit timeout and have been sitting
+ * in 'running' or 'paused' but have expired, and sets them to 'failed'.
+ */
 const scheduledCleanUpByTimeout: (
   e: WorkflowEngine,
   db: Db,
   config?: ScheduledCleanUpByTimeoutConfig,
-) => WorkflowDefinition<InputParameters> = (_engine, db, config) =>
+) => WorkflowDefinition<InputParameters> = (engine, db, config) =>
   workflow(
     '__pgw-scheduled-clean-up-by-timeout',
     async ({ step, logger }) => {
@@ -33,22 +38,39 @@ const scheduledCleanUpByTimeout: (
           const rows = expired.rows as { id: string }[];
           const ids = rows.map((r) => r.id);
 
-          if (ids.length === 0) return { cleaned: 0 };
+          if (ids.length === 0) return { selected: 0, cleaned: 0 };
 
           const updated = await db.executeSql(
             `UPDATE workflow_runs
              SET status = 'failed', error = COALESCE(error, 'Workflow run timed out'), updated_at = NOW()
-             WHERE id = ANY($1)
-             RETURNING id`,
+             WHERE id = ANY($1) AND status IN ('running','paused') AND timeout_at < NOW()
+             RETURNING id, parent_run_id, parent_step_id, parent_resource_id`,
             [ids],
           );
 
-          return { cleaned: updated.rows.length };
+          const updatedRows = updated.rows as {
+            id: string;
+            parent_run_id: string | null;
+            parent_step_id: string | null;
+            parent_resource_id: string | null;
+          }[];
+
+          for (const r of updatedRows) {
+            if (r.parent_run_id) {
+              await engine.notifyParentOfChildTerminalRun({
+                id: r.id,
+                parentRunId: r.parent_run_id,
+                parentStepId: r.parent_step_id,
+                parentResourceId: r.parent_resource_id,
+              });
+            }
+          }
+          return { selected: ids.length, cleaned: updated.rows.length };
         });
 
         totalCleaned += cleanUpAPageResult.cleaned;
 
-        if (cleanUpAPageResult.cleaned < PAGE) {
+        if (cleanUpAPageResult.selected < PAGE) {
           drained = true;
           break;
         }


### PR DESCRIPTION
## Clean up workflow for expired workflows by `timeout_at`
Addresses https://github.com/SokratisVidros/pg-workflows/issues/17

### What this does
Introduces a new idea about meta workflows that get registered by default. In this case it adds a meta workflow (`__pgw-scheduled-clean-up-by-timeout`) that runs on a recurring schedule and fails runs whose `timeout_at` has passed. That way we get scheduled clean up for workflow runs that have expired and at the same time we benefit from the robustness of a workflow. 

### Implementation Details
- **Scheduled reaper** — selects `status IN ('running','paused') AND timeout_at < NOW()` and marks them `failed`.
- **Paginated + crash-safe** — one durable `step.run` per page (`clean-page-${n}`) so completed pages are cached and skipped on retry; a trailing static `clean-up-done` step guarantees completion.
- **Per-run cap** — `maxPagesPerRun` bounds work per fire; remaining runs are picked up on the next fire.
- **Self-immune** — the reaper sets no timeout, so it can't reap itself.

### Infrastructure added
- **Default-workflow registry** (`meta-workflows/index.ts`) — type-safe key→config→factory mapping; new defaults are one line.
- **Engine wiring** — defaults always register; new `defaultWorkflowOptions` option lets callers override per-workflow `config` or `disable` defaults by key.
- Cleanup workflow `config` is fully optional with per-field defaults (pass `{ schedule: '30m' }` and inherit the rest).

### New Pattern Implications
If this pattern is accepted, it could open the way for solutions to tasks like this https://github.com/SokratisVidros/pg-workflows/issues/18

### Testing
- `npm run test:unit`
- `npm run test:integration`
- Type-check clean.

### End-to-end simulation (Docker + real Postgres)

**Setup — all real, no mocks:**
- **Postgres 16** in Docker.
- Library consumed as the **published artifact**: `npm run build` → `npm pack` → installed the `.tgz` into a standalone Node ESM app (+ `pg`).
- App defines a `stuck-job` workflow (`{ timeout: 5_000 }`) that parks on `step.waitFor('approved')` — an event that never arrives. The built-in reaper was sped from its 10-min default to `'1m'` via `defaultWorkflowOptions.configs`.

**Timeline:**

```
t+0s    stuck-job started — running, timeout_at = +5s
~0.5s   handler hits waitFor → paused
t+6s    now > timeout_at → stuck PAUSED past its timeout
t+66s   ⏰ scheduled reaper fires (cron */1):
          clean-page-0 → clean-up-done → "Cleaned 1"  (run COMPLETED, output { totalCleaned: 1 })
t+69s   stuck-job → FAILED, error="Workflow run timed out"
```

**Confirmed in Postgres:**

```
 workflow_id                          | status    | error                  | completed_at
--------------------------------------+-----------+------------------------+-------------
 stuck-job                            | failed    | Workflow run timed out | (null)
 __pgw-scheduled-clean-up-by-timeout  | completed |                        | set
```

**Result:**
 ✅ expired run reaped `paused → failed` with the correct message, **by the scheduled reaper on its own** (manual fallback never ran) 
✅ reaper reported `{ totalCleaned: 1 }` and completed 
✅ self-immune (its own run has `timeout_at = NULL`) 
✅ works against real Postgres via the packaged library, end to end.


