### PR TITLE
feat: workflow priorities via pg-boss

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,11 +75,41 @@ const myWorkflow = workflow(
     inputSchema: z.object({ /* ... */ }),      // optional Zod schema
     timeout: 60000,                            // optional, milliseconds
     retries: 3,                                // optional, max retry count
+    priority: 'high',                          // optional default priority for every run
     schedule: '*/5 * * * *',                   // optional, recurring schedule (cron or duration)
     timezone: 'America/New_York',              // optional, only meaningful for cron (default: UTC)
   }
 );
 ```
+
+### Workflow priorities
+
+Runs can be prioritized in pg-boss's queue. `priority` accepts a named level
+(`'high'`, `'normal'`, `'low'`) or a raw integer — **higher runs first**, and
+`'normal'` is `0` (pg-boss's default). Named levels map to `high = 100`,
+`normal = 0`, `low = -100`; the numeric escape hatch is for fine-grained tuning.
+
+Priority can be set on the workflow definition (default for every run) and
+overridden per-run at `startWorkflow`:
+
+```typescript
+workflow('billing', handler, { priority: 'high' });   // every run defaults to high
+
+await engine.startWorkflow({
+  workflowId: 'billing',
+  priority: 'low',     // this run only; overrides the definition default
+});
+```
+
+**Resolution.** Effective priority is `startWorkflow.priority ?? definition.priority ?? 'normal'`,
+resolved to an integer once when the run row is created and **persisted on the
+run**. Every subsequent re-enqueue (resume after `waitFor`/`pause`, retries,
+poll/`waitUntil` continuations, scheduled fires) reuses the stored value, so a
+high-priority workflow stays high-priority across pauses.
+
+**Child workflows** inherit the parent run's priority by default; the child's
+own definition or call-site `priority` overrides it:
+`childCall.priority ?? childDefinition.priority ?? parentRun.priority`.
 
 ### Recurring workflows
 
@@ -212,7 +242,7 @@ const run = await engine.startWorkflow({
   resourceId: 'user-123',            // optional, for scoping/multi-tenancy
   input: { email: 'user@example.com' },
   idempotencyKey: 'unique-key-123',  // optional, for deduplication
-  options: { timeout, retries, expireInSeconds }, // all optional
+  options: { timeout, retries, expireInSeconds, priority }, // all optional
 });
 
 // Pause / Resume / Cancel
@@ -295,6 +325,7 @@ type WorkflowRun = {
   timeoutAt: Date | null;
   retryCount: number;
   maxRetries: number;
+  priority: number;
   jobId: string | null;
 };
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -24,6 +24,7 @@ import {
   WorkflowEngineError,
   WorkflowRunNotFoundError,
 } from './error';
+import { resolvePriority } from './priority';
 import {
   type InferInputParameters,
   type InputParameters,
@@ -211,6 +212,7 @@ export class WorkflowClient {
             status: WorkflowStatus.RUNNING,
             input,
             maxRetries: options?.retries ?? 0,
+            priority: resolvePriority(options?.priority),
             timeoutAt,
             idempotencyKey,
           },
@@ -232,6 +234,7 @@ export class WorkflowClient {
           await this.boss.send(WORKFLOW_RUN_QUEUE_NAME, job, {
             startAfter: new Date(),
             expireInSeconds: options?.expireInSeconds ?? defaultExpireInSeconds,
+            priority: insertedRun.priority,
             db: _db,
           });
         }
@@ -276,6 +279,7 @@ export class WorkflowClient {
 
     await this.boss.send(WORKFLOW_RUN_QUEUE_NAME, job, {
       expireInSeconds: options?.expireInSeconds ?? defaultExpireInSeconds,
+      priority: run.priority,
     });
 
     this.logger.log(`${LOG_PREFIX} Event ${eventName} sent for workflow run ${runId}`);

--- a/src/db/migration.test.ts
+++ b/src/db/migration.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { closeTestDatabase, createTestDatabase } from '../tests/test-db';
 import { runMigrations } from './migration';
 
-const CURRENT_SCHEMA_VERSION = 5;
+const CURRENT_SCHEMA_VERSION = 6;
 
 describe('runMigrations', () => {
   let pool: pg.Pool;
@@ -42,6 +42,26 @@ describe('runMigrations', () => {
     expect(await tableExists('workflow_runs')).toBe(true);
     expect(await tableExists('workflow_schema_version')).toBe(true);
     expect(await schemaVersion()).toBe(CURRENT_SCHEMA_VERSION);
+  });
+
+  it('adds a non-null priority column defaulting to 0', async () => {
+    await runMigrations(db);
+
+    const result = await db.executeSql(
+      `SELECT data_type, is_nullable, column_default FROM information_schema.columns
+       WHERE table_schema = current_schema() AND table_name = 'workflow_runs' AND column_name = 'priority'`,
+      [],
+    );
+
+    expect(result.rows).toHaveLength(1);
+    const col = result.rows[0] as {
+      data_type: string;
+      is_nullable: string;
+      column_default: string;
+    };
+    expect(col.data_type).toBe('integer');
+    expect(col.is_nullable).toBe('NO');
+    expect(col.column_default).toBe('0');
   });
 
   it('is idempotent when run repeatedly', async () => {

--- a/src/db/migration.ts
+++ b/src/db/migration.ts
@@ -5,7 +5,7 @@ export const MIGRATION_LOCK_ID = 738291645;
 
 // Bump this when adding new migrations. The engine stores the current version
 // in a `workflow_schema_version` table so migrations only run once per version.
-const CURRENT_SCHEMA_VERSION = 5;
+const CURRENT_SCHEMA_VERSION = 6;
 
 export async function runMigrations(db: Db): Promise<void> {
   // Fast path: skip the advisory lock if schema is already current.
@@ -122,6 +122,12 @@ export async function runMigrations(db: Db): Promise<void> {
   if (currentVersion < 5) {
     commands.push(
       'ALTER TABLE workflow_runs ADD COLUMN IF NOT EXISTS scheduled_at timestamp with time zone',
+    );
+  }
+
+  if (currentVersion < 6) {
+    commands.push(
+      'ALTER TABLE workflow_runs ADD COLUMN IF NOT EXISTS priority integer DEFAULT 0 NOT NULL',
     );
   }
 

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -24,6 +24,7 @@ type WorkflowRunRow = {
   timeout_at: string | Date | null;
   retry_count: number;
   max_retries: number;
+  priority: number;
   job_id: string | null;
   idempotency_key: string | null;
   parent_run_id: string | null;
@@ -56,6 +57,7 @@ function mapRowToWorkflowRun(row: WorkflowRunRow): WorkflowRun {
     timeoutAt: row.timeout_at ? new Date(row.timeout_at) : null,
     retryCount: row.retry_count,
     maxRetries: row.max_retries,
+    priority: row.priority,
     jobId: row.job_id,
     idempotencyKey: row.idempotency_key,
     parentRunId: row.parent_run_id,
@@ -73,6 +75,7 @@ export async function insertWorkflowRun(
     status,
     input,
     maxRetries,
+    priority,
     timeoutAt,
     idempotencyKey,
     parentRunId,
@@ -86,6 +89,7 @@ export async function insertWorkflowRun(
     status: string;
     input: unknown;
     maxRetries: number;
+    priority: number;
     timeoutAt: Date | null;
     idempotencyKey?: string;
     parentRunId?: string;
@@ -107,6 +111,7 @@ export async function insertWorkflowRun(
       status,
       input,
       max_retries,
+      priority,
       timeout_at,
       created_at,
       updated_at,
@@ -118,7 +123,7 @@ export async function insertWorkflowRun(
       parent_resource_id,
       scheduled_at
     )
-    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
     ON CONFLICT (idempotency_key) WHERE idempotency_key IS NOT NULL DO NOTHING
     RETURNING *`,
     [
@@ -129,6 +134,7 @@ export async function insertWorkflowRun(
       status,
       JSON.stringify(input),
       maxRetries,
+      priority,
       timeoutAt,
       now,
       now,

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -16,6 +16,8 @@ export type WorkflowRun = {
   timeoutAt: Date | null;
   retryCount: number;
   maxRetries: number;
+  /** Resolved scheduling priority (pg-boss integer; higher runs first). */
+  priority: number;
   jobId: string | null;
   idempotencyKey: string | null;
   parentRunId: string | null;

--- a/src/definition.ts
+++ b/src/definition.ts
@@ -28,6 +28,7 @@ export function createWorkflowRef<
     inputSchema: options?.inputSchema,
     timeout: defineOptions?.timeout,
     retries: defineOptions?.retries,
+    priority: defineOptions?.priority,
     schedule: defineOptions?.schedule,
     timezone: defineOptions?.timezone,
   })) as WorkflowRef<TInput, TOutput>;
@@ -47,7 +48,7 @@ function createWorkflowFactory<TStepExt extends object = object>(
   const factory = (<I extends InputParameters>(
     id: string,
     handler: (context: WorkflowContext<I, StepBaseContext & TStepExt>) => Promise<unknown>,
-    { inputSchema, timeout, retries, schedule, timezone }: WorkflowOptions<I> = {},
+    { inputSchema, timeout, retries, priority, schedule, timezone }: WorkflowOptions<I> = {},
   ): WorkflowDefinition<I> => ({
     id,
     handler: handler as (
@@ -56,6 +57,7 @@ function createWorkflowFactory<TStepExt extends object = object>(
     inputSchema,
     timeout,
     retries,
+    priority,
     schedule,
     timezone,
     plugins: plugins.length > 0 ? (plugins as WorkflowPlugin[]) : undefined,

--- a/src/engine.test.ts
+++ b/src/engine.test.ts
@@ -577,6 +577,121 @@ describe('WorkflowEngine', () => {
       expect(run.timeoutAt).toBeDefined();
     });
 
+    it('should persist the resolved per-run priority', async () => {
+      const run = await engine.startWorkflow({
+        resourceId,
+        workflowId: 'test-workflow',
+        input: { data: '42' },
+        options: { priority: 'high' },
+      });
+
+      expect(run.priority).toBe(100);
+      const fetched = await engine.getRun({ runId: run.id, resourceId });
+      expect(fetched.priority).toBe(100);
+    });
+
+    it('should default to normal priority (0) when none is set', async () => {
+      const run = await engine.startWorkflow({
+        resourceId,
+        workflowId: 'test-workflow',
+        input: { data: '42' },
+      });
+
+      expect(run.priority).toBe(0);
+    });
+
+    it('should use the definition priority as the default', async () => {
+      const prioritizedWorkflow = workflow(
+        'high-priority-workflow',
+        async ({ step }) => {
+          return await step.run('step-1', async () => 'done');
+        },
+        { priority: 'high' },
+      );
+      await engine.registerWorkflow(prioritizedWorkflow);
+
+      const run = await engine.startWorkflow({
+        workflowId: 'high-priority-workflow',
+        input: {},
+      });
+
+      expect(run.priority).toBe(100);
+    });
+
+    it('should let a per-run priority override the definition default', async () => {
+      const prioritizedWorkflow = workflow(
+        'override-priority-workflow',
+        async ({ step }) => {
+          return await step.run('step-1', async () => 'done');
+        },
+        { priority: 'high' },
+      );
+      await engine.registerWorkflow(prioritizedWorkflow);
+
+      const run = await engine.startWorkflow({
+        workflowId: 'override-priority-workflow',
+        input: {},
+        options: { priority: 'low' },
+      });
+
+      expect(run.priority).toBe(-100);
+    });
+
+    it('should forward the resolved priority to pg-boss when enqueueing', async () => {
+      const sendSpy = vi.spyOn(testBoss, 'send');
+      try {
+        await engine.startWorkflow({
+          resourceId,
+          workflowId: 'test-workflow',
+          input: { data: '42' },
+          options: { priority: 250 },
+        });
+
+        expect(sendSpy).toHaveBeenCalledWith(
+          WORKFLOW_RUN_QUEUE_NAME,
+          expect.anything(),
+          expect.objectContaining({ priority: 250 }),
+        );
+      } finally {
+        sendSpy.mockRestore();
+      }
+    });
+
+    it('should make a child workflow inherit the parent run priority', async () => {
+      const childWorkflow = workflow('inherit-child', async ({ step }) => {
+        await step.waitFor('child-wait', { eventName: 'child-ready' });
+        return 'child-done';
+      });
+      const parentWorkflow = workflow(
+        'inherit-parent',
+        async ({ step }) => {
+          await step.invokeChildWorkflow('call-child', {
+            workflowId: 'inherit-child',
+            input: {},
+          });
+          return 'parent-done';
+        },
+        { priority: 'high' },
+      );
+      await engine.registerWorkflow(childWorkflow);
+      await engine.registerWorkflow(parentWorkflow);
+
+      const parentRun = await engine.startWorkflow({
+        resourceId,
+        workflowId: 'inherit-parent',
+        input: {},
+      });
+      expect(parentRun.priority).toBe(100);
+
+      await expect
+        .poll(async () => (await engine.getRun({ runId: parentRun.id, resourceId })).status)
+        .toBe(WorkflowStatus.PAUSED);
+
+      const childRuns = await engine.getRuns({ resourceId, workflowId: 'inherit-child' });
+      expect(childRuns.items).toHaveLength(1);
+      expect(childRuns.items[0].priority).toBe(100);
+    });
+
     it('should throw error for unknown workflow', async () => {
       await expect(
         engine.startWorkflow({

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -30,6 +30,7 @@ import {
   WorkflowEngineError,
   WorkflowRunNotFoundError,
 } from './error';
+import { resolvePriority } from './priority';
 import { resolveSchedule } from './schedule';
 import {
   type InferInputParameters,
@@ -499,6 +500,7 @@ export class WorkflowEngine {
     parentRunId: string;
     parentStepId: string;
     parentResourceId?: string;
+    parentPriority?: number;
     scheduledAt?: Date;
     enqueue?: boolean;
     db?: Db;
@@ -515,6 +517,7 @@ export class WorkflowEngine {
     parentRunId,
     parentStepId,
     parentResourceId,
+    parentPriority,
     scheduledAt,
     enqueue = true,
     db,
@@ -527,6 +530,7 @@ export class WorkflowEngine {
     parentRunId?: string;
     parentStepId?: string;
     parentResourceId?: string;
+    parentPriority?: number;
     scheduledAt?: Date;
     enqueue?: boolean;
     db?: Db;
@@ -573,6 +577,7 @@ export class WorkflowEngine {
           status: WorkflowStatus.RUNNING,
           input,
           maxRetries: options?.retries ?? workflow.retries ?? 0,
+          priority: resolvePriority(options?.priority, workflow.priority, parentPriority),
           timeoutAt,
           idempotencyKey,
           parentRunId,
@@ -618,6 +623,7 @@ export class WorkflowEngine {
     await this.boss.send(WORKFLOW_RUN_QUEUE_NAME, job, {
       startAfter: new Date(),
       expireInSeconds: options?.expireInSeconds ?? defaultExpireInSeconds,
+      priority: run.priority,
       ...retrySendOptions(run.maxRetries),
       ...(db ? { db } : {}),
     });
@@ -847,6 +853,7 @@ export class WorkflowEngine {
 
     await this.boss.send(WORKFLOW_RUN_QUEUE_NAME, job, {
       expireInSeconds: options?.expireInSeconds ?? defaultExpireInSeconds,
+      priority: run.priority,
       ...retrySendOptions(run.maxRetries),
     });
 
@@ -1552,6 +1559,7 @@ export class WorkflowEngine {
           parentRunId: run.id,
           parentStepId: stepId,
           parentResourceId: run.resourceId ?? undefined,
+          parentPriority: run.priority,
           enqueue: true,
           db,
         });
@@ -1836,6 +1844,7 @@ export class WorkflowEngine {
         await this.boss.send(WORKFLOW_RUN_QUEUE_NAME, job, {
           startAfter: timeoutDate.getTime() <= Date.now() ? new Date() : timeoutDate,
           expireInSeconds: defaultExpireInSeconds,
+          priority: run.priority,
           ...retrySendOptions(run.maxRetries),
         });
       } catch (error) {
@@ -2031,6 +2040,7 @@ export class WorkflowEngine {
         {
           startAfter: new Date(Date.now() + intervalMs),
           expireInSeconds: defaultExpireInSeconds,
+          priority: run.priority,
           ...retrySendOptions(run.maxRetries),
         },
       );

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export type { Duration } from './duration';
 export { WorkflowEngine, type WorkflowEngineOptions } from './engine';
 export { WorkflowEngineError, WorkflowRunNotFoundError } from './error';
 export { type OtelPluginOptions, otelPlugin } from './plugins/otel';
+export type { WorkflowPriority } from './priority';
 export type { Schedule } from './schedule';
 export type {
   InferInputParameters,

--- a/src/migration-lock.integration.test.ts
+++ b/src/migration-lock.integration.test.ts
@@ -55,7 +55,7 @@ describe('Migration advisory lock (real PostgreSQL)', () => {
 
     // Verify the final schema state is correct
     const versionResult = await pool.query('SELECT version FROM workflow_schema_version LIMIT 1');
-    expect(versionResult.rows[0].version).toBe(5);
+    expect(versionResult.rows[0].version).toBe(6);
 
     const tableExists = await pool.query(`
       SELECT EXISTS (

--- a/src/priority.test.ts
+++ b/src/priority.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { WorkflowEngineError } from './error';
+import { PRIORITY_LEVELS, resolvePriority } from './priority';
+
+describe('resolvePriority', () => {
+  describe('named levels', () => {
+    it('maps named levels to their integer values', () => {
+      expect(resolvePriority('high')).toBe(100);
+      expect(resolvePriority('normal')).toBe(0);
+      expect(resolvePriority('low')).toBe(-100);
+    });
+
+    it('exposes the level mapping as a frozen table', () => {
+      expect(PRIORITY_LEVELS).toEqual({ high: 100, normal: 0, low: -100 });
+    });
+  });
+
+  describe('numeric escape hatch', () => {
+    it('passes integers through unchanged', () => {
+      expect(resolvePriority(250)).toBe(250);
+      expect(resolvePriority(0)).toBe(0);
+      expect(resolvePriority(-50)).toBe(-50);
+    });
+
+    it('throws on non-integer numbers', () => {
+      expect(() => resolvePriority(1.5)).toThrow(WorkflowEngineError);
+    });
+
+    it('throws on non-finite numbers', () => {
+      expect(() => resolvePriority(Number.NaN)).toThrow(WorkflowEngineError);
+      expect(() => resolvePriority(Number.POSITIVE_INFINITY)).toThrow(WorkflowEngineError);
+    });
+  });
+
+  describe('invalid input', () => {
+    it('throws on an unknown named level', () => {
+      // @ts-expect-error runtime guard for dynamic values
+      expect(() => resolvePriority('urgent')).toThrow(WorkflowEngineError);
+    });
+  });
+
+  describe('precedence chain', () => {
+    it('returns the first defined candidate', () => {
+      expect(resolvePriority('low', 'high')).toBe(-100);
+      expect(resolvePriority(undefined, 'high')).toBe(100);
+      expect(resolvePriority(undefined, undefined, 42)).toBe(42);
+    });
+
+    it('defaults to normal (0) when nothing is defined', () => {
+      expect(resolvePriority()).toBe(0);
+      expect(resolvePriority(undefined, undefined)).toBe(0);
+    });
+
+    it('treats an explicit 0 as defined, not a fallthrough', () => {
+      expect(resolvePriority(0, 'high')).toBe(0);
+    });
+  });
+});

--- a/src/priority.ts
+++ b/src/priority.ts
@@ -1,0 +1,47 @@
+import { WorkflowEngineError } from './error';
+
+/**
+ * Named priority levels mapped to pg-boss integer priorities. Higher numbers
+ * are fetched first (pg-boss orders by `priority DESC`), and `normal = 0`
+ * matches pg-boss's own default. The ±100 spacing leaves room for numeric
+ * tuning between tiers via the escape hatch.
+ */
+export const PRIORITY_LEVELS = { high: 100, normal: 0, low: -100 } as const;
+
+export type WorkflowPriority = keyof typeof PRIORITY_LEVELS | number;
+
+function priorityToInt(value: WorkflowPriority): number {
+  if (typeof value === 'number') {
+    if (!Number.isInteger(value)) {
+      throw new WorkflowEngineError(
+        `Invalid priority ${value}: numeric priority must be an integer.`,
+      );
+    }
+    return value;
+  }
+
+  const mapped = PRIORITY_LEVELS[value];
+  if (mapped === undefined) {
+    throw new WorkflowEngineError(
+      `Invalid priority "${value}": expected one of ${Object.keys(PRIORITY_LEVELS)
+        .map((k) => `"${k}"`)
+        .join(', ')} or an integer.`,
+    );
+  }
+  return mapped;
+}
+
+/**
+ * Resolve the effective priority from a precedence chain. The first defined
+ * candidate wins (e.g. per-run override, then definition default, then an
+ * inherited parent priority); when nothing is defined it falls back to
+ * normal (0).
+ */
+export function resolvePriority(...candidates: (WorkflowPriority | undefined)[]): number {
+  for (const candidate of candidates) {
+    if (candidate !== undefined) {
+      return priorityToInt(candidate);
+    }
+  }
+  return PRIORITY_LEVELS.normal;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,11 +32,6 @@ export type StartWorkflowOptions = {
   retries?: number;
   expireInSeconds?: number;
   idempotencyKey?: string;
-  /**
-   * Per-run scheduling priority. Accepts a named level (`'high'`, `'normal'`,
-   * `'low'`) or a raw integer (higher runs first). Overrides the workflow
-   * definition's `priority`. Defaults to `'normal'` (0).
-   */
   priority?: WorkflowPriority;
 };
 
@@ -44,11 +39,6 @@ export type WorkflowOptions<I extends InputParameters> = {
   timeout?: number;
   retries?: number;
   inputSchema?: I;
-  /**
-   * Default scheduling priority for every run of this workflow. Accepts a
-   * named level (`'high'`, `'normal'`, `'low'`) or a raw integer (higher runs
-   * first). A per-run `priority` passed to `startWorkflow` overrides this.
-   */
   priority?: WorkflowPriority;
   /**
    * Recurring schedule. Accepts a cron expression (`'0 9 * * 1-5'`),

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import type { StandardSchemaV1 } from '@standard-schema/spec';
 import type { WorkflowRun } from './db/types';
 import type { Duration } from './duration';
+import type { WorkflowPriority } from './priority';
 import type { Schedule } from './schedule';
 
 export enum WorkflowStatus {
@@ -31,12 +32,24 @@ export type StartWorkflowOptions = {
   retries?: number;
   expireInSeconds?: number;
   idempotencyKey?: string;
+  /**
+   * Per-run scheduling priority. Accepts a named level (`'high'`, `'normal'`,
+   * `'low'`) or a raw integer (higher runs first). Overrides the workflow
+   * definition's `priority`. Defaults to `'normal'` (0).
+   */
+  priority?: WorkflowPriority;
 };
 
 export type WorkflowOptions<I extends InputParameters> = {
   timeout?: number;
   retries?: number;
   inputSchema?: I;
+  /**
+   * Default scheduling priority for every run of this workflow. Accepts a
+   * named level (`'high'`, `'normal'`, `'low'`) or a raw integer (higher runs
+   * first). A per-run `priority` passed to `startWorkflow` overrides this.
+   */
+  priority?: WorkflowPriority;
   /**
    * Recurring schedule. Accepts a cron expression (`'0 9 * * 1-5'`),
    * a duration string (`'5m'`, `'1 hour'`), or a `DurationObject`.
@@ -144,6 +157,7 @@ export type WorkflowDefinition<TInput extends InputParameters = InputParameters>
   inputSchema?: TInput;
   timeout?: number; // milliseconds
   retries?: number;
+  priority?: WorkflowPriority;
   schedule?: Schedule;
   timezone?: string;
   plugins?: WorkflowPlugin[];


### PR DESCRIPTION
## What

Adds scheduling **priorities** to workflows, backed by pg-boss's native job priority (`priority DESC` fetch order — higher runs first, `normal = 0` matching pg-boss's default).

## DX

`WorkflowPriority = 'high' | 'normal' | 'low' | number` — named levels (`high=100`, `normal=0`, `low=-100`) with a raw-integer escape hatch for fine-grained tuning.

Settable in two places, mirroring `timeout`/`retries`:

```ts
workflow('billing', handler, { priority: 'high' });   // default for every run

await engine.startWorkflow({
  workflowId: 'billing',
  options: { priority: 'low' },   // this run only; overrides the definition default
});
```

## Resolution & persistence

- **Effective priority** = `runOption ?? definitionDefault ?? parentInherited ?? normal(0)`, resolved to an integer **once at run creation** and **persisted on the `workflow_runs` row** (new `priority integer NOT NULL DEFAULT 0` column, schema **v6**, additive migration).
- Every re-enqueue reads the stored value, so a run keeps its priority across pauses: initial enqueue, resume after `waitFor`/`pause`, retries, `waitUntil`/poll continuations, scheduled fires, and the client's `triggerEvent`.
- **Child workflows** inherit the parent run's priority unless they set their own definition/call-site priority.

## Out of scope (YAGNI)

- No `ctx.priority` in handlers.
- No dynamic re-prioritization of an already-queued run (`engine.setPriority()`) — easy follow-up if wanted.

## Tests

- `resolvePriority` unit tests (named mapping, integer pass-through, validation, precedence chain).
- Engine tests: persistence, definition default, per-run override, **pg-boss forwarding**, **child inheritance**.
- Migration test asserting the new non-null `priority` column defaults to `0`.

## Verification

- ✅ `npm run test:unit` — 184 passed (PGlite; exercises migration + SQL + engine paths)
- ✅ `npm run lint`, ✅ `npm run build`, ✅ no type errors
- ⚠️ `npm run test:integration` **not run** — no PostgreSQL available in the dev environment. Worth running against real Postgres before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)